### PR TITLE
FolioGovernor proposal threshold

### DIFF
--- a/contracts/governance/FolioGovernor.sol
+++ b/contracts/governance/FolioGovernor.sol
@@ -21,6 +21,7 @@ contract FolioGovernor is
     GovernorVotesQuorumFractionUpgradeable,
     GovernorTimelockControlUpgradeable
 {
+    error Governor__InvalidProposalThreshold();
     error Governor__ZeroSupply();
 
     /// @custom:oz-upgrades-unsafe-allow constructor
@@ -41,6 +42,11 @@ contract FolioGovernor is
         __GovernorVotes_init(_token);
         __GovernorVotesQuorumFraction_init(quorumPercent);
         __GovernorTimelockControl_init(_timelock);
+    }
+
+    function setProposalThreshold(uint256 newProposalThreshold) public override {
+        require(newProposalThreshold <= 1e18, Governor__InvalidProposalThreshold());
+        super.setProposalThreshold(newProposalThreshold);
     }
 
     function votingDelay() public view override(GovernorUpgradeable, GovernorSettingsUpgradeable) returns (uint256) {

--- a/contracts/governance/FolioGovernor.sol
+++ b/contracts/governance/FolioGovernor.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.28;
 
+import { Math } from "@openzeppelin/contracts/utils/math/Math.sol";
 import "@openzeppelin/contracts-upgradeable/governance/GovernorUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/governance/extensions/GovernorSettingsUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/governance/extensions/GovernorCountingSimpleUpgradeable.sol";
@@ -22,7 +23,6 @@ contract FolioGovernor is
     GovernorTimelockControlUpgradeable
 {
     error Governor__InvalidProposalThreshold();
-    error Governor__ZeroSupply();
 
     /// @custom:oz-upgrades-unsafe-allow constructor
     constructor() {
@@ -82,8 +82,7 @@ contract FolioGovernor is
         returns (uint256)
     {
         uint256 threshold = super.proposalThreshold(); // D18{1}
-        uint256 pastSupply = token().getPastTotalSupply(clock() - 1);
-        require(pastSupply != 0, Governor__ZeroSupply());
+        uint256 pastSupply = Math.max(1, token().getPastTotalSupply(clock() - 1));
 
         // CEIL to make sure thresholds near 0% don't get rounded down to 0 tokens
         return (threshold * pastSupply + (1e18 - 1)) / 1e18;

--- a/contracts/governance/FolioGovernor.sol
+++ b/contracts/governance/FolioGovernor.sol
@@ -21,6 +21,8 @@ contract FolioGovernor is
     GovernorVotesQuorumFractionUpgradeable,
     GovernorTimelockControlUpgradeable
 {
+    error Governor__ZeroSupply();
+
     /// @custom:oz-upgrades-unsafe-allow constructor
     constructor() {
         _disableInitializers();
@@ -75,6 +77,7 @@ contract FolioGovernor is
     {
         uint256 threshold = super.proposalThreshold(); // D18{1}
         uint256 pastSupply = token().getPastTotalSupply(clock() - 1);
+        require(pastSupply != 0, Governor__ZeroSupply());
 
         // CEIL to make sure thresholds near 0% don't get rounded down to 0 tokens
         return (threshold * pastSupply + (1e18 - 1)) / 1e18;

--- a/test/Governance.t.sol
+++ b/test/Governance.t.sol
@@ -244,4 +244,24 @@ contract GovernanceTest is BaseTest {
         assertEq(uint256(governor.state(pid)), uint256(IGovernor.ProposalState.Canceled));
         assertEq(governor.votingDelay(), 1 days); // no changes
     }
+
+    function test_cannotProposeWhenSupplyZero() public {
+        votingToken.burn(owner, 100e18);
+        assertEq(votingToken.totalSupply(), 0);
+        vm.warp(block.timestamp + 1 days);
+        vm.roll(block.number + 1);
+
+        address[] memory targets = new address[](1);
+        targets[0] = address(governor);
+        uint256[] memory values = new uint256[](1);
+        values[0] = 0;
+        bytes[] memory calldatas = new bytes[](1);
+        calldatas[0] = abi.encodeWithSelector(governor.setVotingDelay.selector, 2 days);
+        string memory description = "desc";
+
+        // attempt to propose
+        vm.expectRevert(FolioGovernor.Governor__ZeroSupply.selector);
+        governor.propose(targets, values, calldatas, description);
+        vm.stopPrank();
+    }
 }

--- a/test/Governance.t.sol
+++ b/test/Governance.t.sol
@@ -264,4 +264,10 @@ contract GovernanceTest is BaseTest {
         governor.propose(targets, values, calldatas, description);
         vm.stopPrank();
     }
+
+    function test_cannotSetProposalThresholdAboveOne() public {
+        vm.prank(owner);
+        vm.expectRevert(FolioGovernor.Governor__InvalidProposalThreshold.selector);
+        governor.setProposalThreshold(1e18 + 1);
+    }
 }

--- a/test/Governance.t.sol
+++ b/test/Governance.t.sol
@@ -260,9 +260,10 @@ contract GovernanceTest is BaseTest {
         string memory description = "desc";
 
         // attempt to propose
-        vm.expectRevert(FolioGovernor.Governor__ZeroSupply.selector);
+        vm.expectRevert(
+            abi.encodeWithSelector(IGovernor.GovernorInsufficientProposerVotes.selector, address(this), 0, 1)
+        );
         governor.propose(targets, values, calldatas, description);
-        vm.stopPrank();
     }
 
     function test_cannotSetProposalThresholdAboveOne() public {


### PR DESCRIPTION
Two tix:
- do not allow above 100%
- prevent proposal creation at 0

I originally wanted to override `propose()` or `_propose()` but it actually can't be done simply. reverting in the view seems like its downsides are acceptable