### PR TITLE
add mint redeem events

### DIFF
--- a/contracts/Folio.sol
+++ b/contracts/Folio.sol
@@ -291,6 +291,7 @@ contract Folio is
         }
 
         // === Mint shares ===
+
         _mint(receiver, shares - totalFeeShares);
         emit FolioMinted(receiver, shares - totalFeeShares);
 

--- a/contracts/Folio.sol
+++ b/contracts/Folio.sol
@@ -148,7 +148,10 @@ contract Folio is
         }
 
         lastPoke = block.timestamp;
+
         _mint(_creator, _basicDetails.initialShares);
+        emit FolioMinted(_creator, _basicDetails.initialShares);
+
         _grantRole(DEFAULT_ADMIN_ROLE, msg.sender);
     }
 
@@ -288,8 +291,8 @@ contract Folio is
         }
 
         // === Mint shares ===
-
         _mint(receiver, shares - totalFeeShares);
+        emit FolioMinted(receiver, shares - totalFeeShares);
 
         // defer fee handouts until distributeFees()
         daoPendingFeeShares += daoFeeShares;
@@ -331,6 +334,8 @@ contract Folio is
                 SafeERC20.safeTransfer(IERC20(_assets[i]), receiver, _amounts[i]);
             }
         }
+
+        emit FolioRedeemed(msg.sender, shares);
     }
 
     // === Fee Shares ===
@@ -357,7 +362,6 @@ contract Folio is
             feeRecipientsTotal += shares;
 
             _mint(feeRecipients[i].recipient, shares);
-
             emit FolioFeePaid(feeRecipients[i].recipient, shares);
         }
 

--- a/contracts/interfaces/IFolio.sol
+++ b/contracts/interfaces/IFolio.sol
@@ -11,6 +11,8 @@ interface IFolio {
     event TradeBid(uint256 indexed tradeId, uint256 sellAmount, uint256 buyAmount);
     event TradeKilled(uint256 indexed tradeId);
 
+    event FolioMinted(address indexed account, uint256 amount);
+    event FolioRedeemed(address indexed account, uint256 amount);
     event FolioFeePaid(address indexed recipient, uint256 amount);
     event ProtocolFeePaid(address indexed recipient, uint256 amount);
 


### PR DESCRIPTION
Adding `FolioMinted` and `FolioRedeemed` events when folio is minted or redeemed to user that creates, mints or redeems a folio. These events do not include "mintings" from fees paid to receivers or the DAO. These have their own specific events already `FolioFeePaid` and `ProtocolFeePaid`