### PR TITLE
efficient ejection of token from basket via Folio purchase

### DIFF
--- a/contracts/Folio.sol
+++ b/contracts/Folio.sol
@@ -1099,16 +1099,23 @@ contract Folio is
     function _update(address from, address to, uint256 value) internal override {
         super._update(from, to, value);
 
-        // only allow transfers to self from activeTrustedFill and activeBidder
-        if (to == address(this)) {
-            if (from == address(activeTrustedFill)) {
-                // burn transfers from activeTrustedFill
-                _burn(address(this), value);
-            } else {
-                // keep transfers from activeBidder
-                // prevent people from accidentally transferring tokens in
-                require(from == address(activeBidder), Folio__InvalidTransferToSelf());
-            }
+        // ignore burns
+        if (to == address(0)) {
+            return;
+        }
+
+        // only allow transfers to self from activeBidder and activeTrustedFill
+        require(
+            to != address(this) || from == address(activeBidder) || from == address(activeTrustedFill),
+            Folio__InvalidTransferToSelf()
+        );
+
+        // burn tokens transferred to/from activeTrustedFill
+        if (
+            address(activeTrustedFill) != address(0) &&
+            (to == address(activeTrustedFill) || from == address(activeTrustedFill))
+        ) {
+            _burn(address(activeTrustedFill), value);
         }
     }
 }

--- a/contracts/Folio.sol
+++ b/contracts/Folio.sol
@@ -1081,7 +1081,8 @@ contract Folio is
         super._update(from, to, value);
 
         if (to == address(this)) {
-            _burn(address(this), balanceOf(address(this)));
+            require(from == address(activeTrustedFill), Folio__InvalidTransferToSelf());
+            _burn(address(this), value);
         }
     }
 }

--- a/contracts/Folio.sol
+++ b/contracts/Folio.sol
@@ -1099,22 +1099,19 @@ contract Folio is
     function _update(address from, address to, uint256 value) internal override {
         super._update(from, to, value);
 
-        // ignore burns
-        if (to == address(0)) {
+        // ignore mints + burns
+        if (from == address(0) || to == address(0)) {
             return;
         }
 
-        // only allow transfers to self from activeBidder and activeTrustedFill
+        // only allow transfers to self from activeBidder/activeTrustedFill
         require(
             to != address(this) || from == address(activeBidder) || from == address(activeTrustedFill),
             Folio__InvalidTransferToSelf()
         );
 
         // burn tokens transferred to/from activeTrustedFill
-        if (
-            address(activeTrustedFill) != address(0) &&
-            (to == address(activeTrustedFill) || from == address(activeTrustedFill))
-        ) {
+        if (to == address(activeTrustedFill) || from == address(activeTrustedFill)) {
             _burn(address(activeTrustedFill), value);
         }
     }

--- a/contracts/Folio.sol
+++ b/contracts/Folio.sol
@@ -1104,15 +1104,17 @@ contract Folio is
             return;
         }
 
-        // only allow transfers to self from activeBidder/activeTrustedFill
+        // only allow transfers in from activeBidder/activeTrustedFill
         require(
             to != address(this) || from == address(activeBidder) || from == address(activeTrustedFill),
             Folio__InvalidTransferToSelf()
         );
 
-        // burn tokens transferred to/from activeTrustedFill
+        // burn tokens at destination when transferring to/from activeTrustedFill
+        //   - to case: totalSupply must be reduced at same time as assets are sold
+        //   - from case: tokens can be sent to activeTrustedFill before it is deployed
         if (to == address(activeTrustedFill) || from == address(activeTrustedFill)) {
-            _burn(address(activeTrustedFill), value);
+            _burn(address(to), value);
         }
     }
 }

--- a/contracts/Folio.sol
+++ b/contracts/Folio.sol
@@ -302,14 +302,6 @@ contract Folio is
         return _totalAssets();
     }
 
-    /// @return _assets
-    /// @return _amounts {tok}
-    function folio() external view returns (address[] memory _assets, uint256[] memory _amounts) {
-        require(!_reentrancyGuardEntered(), ReentrancyGuardReentrantCall());
-
-        return _toAssets(10 ** decimals(), Math.Rounding.Floor);
-    }
-
     /// @param shares {share}
     /// @return _assets
     /// @return _amounts {tok}

--- a/contracts/Folio.sol
+++ b/contracts/Folio.sol
@@ -826,7 +826,9 @@ contract Folio is
         auction.endTime = endTime;
 
         // ensure buy token is in basket since swaps can happen out-of-band
-        _addToBasket(address(auction.buyToken));
+        if (address(auction.buyToken) != address(this)) {
+            _addToBasket(address(auction.buyToken));
+        }
         emit AuctionOpened(auction.id, auction, details.availableRuns);
 
         // D18{1}

--- a/contracts/interfaces/IFolio.sol
+++ b/contracts/interfaces/IFolio.sol
@@ -73,6 +73,7 @@ interface IFolio {
     error Folio__TooManyFeeRecipients();
     error Folio__InvalidArrayLengths();
     error Folio__InvalidAuctionRuns();
+    error Folio__InvalidTransferToSelf();
 
     error Folio__TrustedFillerRegistryNotSet();
     error Folio__TrustedFillerRegistryAlreadySet();

--- a/test/Folio.t.sol
+++ b/test/Folio.t.sol
@@ -1451,17 +1451,18 @@ contract FolioTest is BaseTest {
         IBaseTrustedFiller swap2 = folio.createTrustedFiller(0, cowswapFiller, bytes32(block.timestamp));
         MockERC20(address(USDC)).burn(address(swap2), amt);
         folio.transfer(address(swap2), amt * 1e12);
-        assertEq(USDC.balanceOf(address(folio)), 0, "wrong usdc balance");
+        assertEq(USDC.balanceOf(address(folio)), 0, "wrong usdc balance folio");
+        assertEq(USDC.balanceOf(address(swap2)), 0, "wrong usdc balance swap");
+        assertEq(folio.balanceOf(address(folio)), 0, "wrong folio balance folio");
+        assertEq(folio.balanceOf(address(swap2)), 0, "wrong folio balance swap");
         vm.stopPrank();
 
         // anyone should be able to close, even though it's ideal this happens in the cowswap post-hook
         swap2.closeFiller();
-        assertEq(USDC.balanceOf(address(swap2)), 0, "wrong usdc balance");
-        assertEq(folio.balanceOf(address(swap2)), 0, "wrong folio balance");
-
-        // Folio should have burnt its balance
-        assertEq(USDC.balanceOf(address(folio)), 0, "wrong folio usdc balance");
-        assertEq(folio.balanceOf(address(folio)), 0, "wrong folio folio balance");
+        assertEq(USDC.balanceOf(address(folio)), 0, "wrong usdc balance folio after close");
+        assertEq(USDC.balanceOf(address(swap2)), 0, "wrong usdc balance after close");
+        assertEq(folio.balanceOf(address(folio)), 0, "wrong folio balance folio after close");
+        assertEq(folio.balanceOf(address(swap2)), 0, "wrong folio balance swap after close");
     }
 
     function test_auctionIsValidSignature() public {

--- a/test/Folio.t.sol
+++ b/test/Folio.t.sol
@@ -178,7 +178,7 @@ contract FolioTest is BaseTest {
     }
 
     function test_getFolio() public view {
-        (address[] memory _assets, uint256[] memory _amounts) = folio.folio();
+        (address[] memory _assets, uint256[] memory _amounts) = folio.toAssets(1e18, Math.Rounding.Floor);
         assertEq(_assets.length, 3, "wrong assets length");
         assertEq(_assets[0], address(USDC), "wrong first asset");
         assertEq(_assets[1], address(DAI), "wrong second asset");
@@ -1914,7 +1914,7 @@ contract FolioTest is BaseTest {
         DAI.approve(address(folio), amt * 1e12);
         folio.bid(0, amt - 2, (amt - 2) * 1e12, false, bytes(""));
 
-        (address[] memory tripleBasket, ) = folio.folio();
+        (address[] memory tripleBasket, ) = folio.toAssets(1e18, Math.Rounding.Floor);
         assertEq(tripleBasket.length, 3);
         assertEq(tripleBasket[0], address(USDC));
         assertEq(tripleBasket[1], address(DAI));
@@ -1924,7 +1924,7 @@ contract FolioTest is BaseTest {
 
         folio.bid(0, 1, 1e12, false, bytes(""));
 
-        (address[] memory doubleBasket, ) = folio.folio();
+        (address[] memory doubleBasket, ) = folio.toAssets(1e18, Math.Rounding.Floor);
         assertEq(doubleBasket.length, 2);
         assertEq(doubleBasket[0], address(MEME)); // order reverses after removal
         assertEq(doubleBasket[1], address(DAI));

--- a/test/base/BaseTest.sol
+++ b/test/base/BaseTest.sol
@@ -68,6 +68,8 @@ abstract contract BaseTest is Script, Test {
     address governorImplementation;
     address timelockImplementation;
 
+    address cowswapFiller;
+
     function setUp() public {
         _testSetup();
         // _setUp();
@@ -101,11 +103,11 @@ abstract contract BaseTest is Script, Test {
             governanceDeployer
         );
 
-        CowSwapFiller cowswapFiller = new CowSwapFiller();
+        cowswapFiller = address(new CowSwapFiller());
 
         // register version
         versionRegistry.registerVersion(folioDeployer);
-        trustedFillerRegistry.addTrustedFiller(cowswapFiller);
+        trustedFillerRegistry.addTrustedFiller(CowSwapFiller(cowswapFiller));
 
         deployCoins();
         mintTokens();


### PR DESCRIPTION
I don't disagree this is complicated...but the central conflict arises from supporting both trusted fills and buying the Folio token. The only way I think we can avoid the complexity is by NOT doing this feature, which seems to me to be necessary to eject tokens cleanly, or by forbidding trusted fills in the Folio buy case, which comes at large cost. 

checked with rest of team and it shouldn't be hard to switch them over to `toAssets(1e18, 0)` instead of `folio()`.

to discuss view reentrancy guards Monday