### PR TITLE
efficient ejection of token via Folio buy + burn

### DIFF
--- a/contracts/Folio.sol
+++ b/contracts/Folio.sol
@@ -195,6 +195,11 @@ contract Folio is
         _poke();
     }
 
+    /// @dev Gas-efficient reentrancy guard check
+    function reentrancyGuardEntered() external view {
+        require(!_reentrancyGuardEntered(), ReentrancyGuardReentrantCall());
+    }
+
     // ==== Governance ====
 
     /// Escape hatch function to be used when tokens get acquired not through an auction but
@@ -309,8 +314,6 @@ contract Folio is
     /// @return _assets
     /// @return _amounts {tok}
     function totalAssets() external view returns (address[] memory _assets, uint256[] memory _amounts) {
-        require(!_reentrancyGuardEntered(), ReentrancyGuardReentrantCall());
-
         return _totalAssets();
     }
 
@@ -321,8 +324,6 @@ contract Folio is
         uint256 shares,
         Math.Rounding rounding
     ) external view returns (address[] memory _assets, uint256[] memory _amounts) {
-        require(!_reentrancyGuardEntered(), ReentrancyGuardReentrantCall());
-
         return _toAssets(shares, rounding);
     }
 

--- a/contracts/Folio.sol
+++ b/contracts/Folio.sol
@@ -195,9 +195,9 @@ contract Folio is
         _poke();
     }
 
-    /// @dev Gas-efficient reentrancy guard check
+    /// @dev Re-eentrancy guard check for consuming protocols
     function reentrancyGuardEntered() external view {
-        require(!_reentrancyGuardEntered(), ReentrancyGuardReentrantCall());
+        return _reentrancyGuardEntered();
     }
 
     // ==== Governance ====

--- a/contracts/Folio.sol
+++ b/contracts/Folio.sol
@@ -705,10 +705,7 @@ contract Folio is
             }
         }
 
-        // allow Folio transfers to self from activeBidder
-        if (address(auction.buyToken) == address(this)) {
-            activeBidder = msg.sender;
-        }
+        activeBidder = msg.sender;
 
         // collect payment
         if (withCallback) {
@@ -723,8 +720,8 @@ contract Folio is
         // burn any Folio token purchased in auction
         if (address(auction.buyToken) == address(this)) {
             _burn(address(this), delta);
-            delete activeBidder;
         }
+        delete activeBidder;
     }
 
     /// As an alternative to bidding directly, an in-block async swap can be opened without removing Folio's access

--- a/contracts/Folio.sol
+++ b/contracts/Folio.sol
@@ -1116,7 +1116,7 @@ contract Folio is
 
         // burn incoming transfers from activeTrustedFill
         if (to == address(this) && from == address(activeTrustedFill)) {
-            _burn(address(activeTrustedFill), value);
+            _burn(address(this), value);
         }
         // incoming transfers from activeBidder are burnt by bid()
     }

--- a/contracts/Folio.sol
+++ b/contracts/Folio.sol
@@ -1099,16 +1099,23 @@ contract Folio is
     function _update(address from, address to, uint256 value) internal override {
         super._update(from, to, value);
 
-        // only allow transfers to self from activeTrustedFill and activeBidder
-        if (to == address(this)) {
-            if (from == address(activeTrustedFill)) {
-                // burn transfers from activeTrustedFill
-                _burn(address(this), value);
-            } else {
-                // keep transfers from activeBidder
-                // prevent people from accidentally transferring tokens in
-                require(from == address(activeBidder), Folio__InvalidTransferToSelf());
-            }
+        // ignore burns
+        if (to == address(0)) {
+            return;
+        }
+
+        // only allow transfers to self from activeBidder and activeTrustedFill
+        require(
+            to != address(this) || from == address(activeBidder) || from == address(activeTrustedFill),
+            Folio__InvalidTransferToSelf()
+        );
+
+        // burn tokens transferred to/from activeTrustedFill
+        if (
+            address(activeTrustedFill) != address(0) &&
+            (to == address(activeTrustedFill) || from == address(activeTrustedFill))
+        ) {
+            _burn(address(activeTrustedFill), value);
         }
     }
 }

--- a/contracts/Folio.sol
+++ b/contracts/Folio.sol
@@ -1081,7 +1081,8 @@ contract Folio is
         super._update(from, to, value);
 
         if (to == address(this)) {
-            _burn(address(this), balanceOf(address(this)));
+            require(from == address(activeTrustedFill), Folio__InvalidTransferToSelf());
+            _burn(address(this), value);
         }
     }
 }

--- a/contracts/Folio.sol
+++ b/contracts/Folio.sol
@@ -1099,22 +1099,19 @@ contract Folio is
     function _update(address from, address to, uint256 value) internal override {
         super._update(from, to, value);
 
-        // ignore burns
-        if (to == address(0)) {
+        // ignore mints + burns
+        if (from == address(0) || to == address(0)) {
             return;
         }
 
-        // only allow transfers to self from activeBidder and activeTrustedFill
+        // only allow transfers to self from activeBidder/activeTrustedFill
         require(
             to != address(this) || from == address(activeBidder) || from == address(activeTrustedFill),
             Folio__InvalidTransferToSelf()
         );
 
         // burn tokens transferred to/from activeTrustedFill
-        if (
-            address(activeTrustedFill) != address(0) &&
-            (to == address(activeTrustedFill) || from == address(activeTrustedFill))
-        ) {
+        if (to == address(activeTrustedFill) || from == address(activeTrustedFill)) {
             _burn(address(activeTrustedFill), value);
         }
     }

--- a/contracts/Folio.sol
+++ b/contracts/Folio.sol
@@ -1104,15 +1104,17 @@ contract Folio is
             return;
         }
 
-        // only allow transfers to self from activeBidder/activeTrustedFill
+        // only allow transfers in from activeBidder/activeTrustedFill
         require(
             to != address(this) || from == address(activeBidder) || from == address(activeTrustedFill),
             Folio__InvalidTransferToSelf()
         );
 
-        // burn tokens transferred to/from activeTrustedFill
+        // burn tokens at destination when transferring to/from activeTrustedFill
+        //   - to case: totalSupply must be reduced at same time as assets are sold
+        //   - from case: tokens can be sent to activeTrustedFill before it is deployed
         if (to == address(activeTrustedFill) || from == address(activeTrustedFill)) {
-            _burn(address(activeTrustedFill), value);
+            _burn(address(to), value);
         }
     }
 }

--- a/contracts/Folio.sol
+++ b/contracts/Folio.sol
@@ -196,7 +196,7 @@ contract Folio is
     }
 
     /// @dev Re-eentrancy guard check for consuming protocols
-    function reentrancyGuardEntered() external view {
+    function reentrancyGuardEntered() external view returns (bool) {
         return _reentrancyGuardEntered();
     }
 

--- a/contracts/Folio.sol
+++ b/contracts/Folio.sol
@@ -714,12 +714,11 @@ contract Folio is
             auction.buyToken.safeTransferFrom(msg.sender, address(this), boughtAmt);
         }
 
-        uint256 delta = auction.buyToken.balanceOf(address(this)) - buyBalBefore;
-        require(delta >= boughtAmt, Folio__InsufficientBid());
+        require(auction.buyToken.balanceOf(address(this)) - buyBalBefore >= boughtAmt, Folio__InsufficientBid());
 
-        // burn any Folio token purchased in auction
-        if (address(auction.buyToken) == address(this)) {
-            _burn(address(this), delta);
+        // burn any held Folio token
+        if (balanceOf(address(this)) != 0) {
+            _burn(address(this), balanceOf(address(this)));
         }
         delete activeBidder;
     }

--- a/contracts/Folio.sol
+++ b/contracts/Folio.sol
@@ -745,7 +745,7 @@ contract Folio is
         );
 
         // Create Trusted Filler
-        filler = trustedFillerRegistry.createTrustedFill(msg.sender, targetFiller, deploymentSalt);
+        filler = trustedFillerRegistry.createTrustedFiller(msg.sender, targetFiller, deploymentSalt);
         auction.sellToken.forceApprove(address(filler), sellAmount);
 
         filler.initialize(address(this), auction.sellToken, auction.buyToken, sellAmount, buyAmount);

--- a/contracts/Folio.sol
+++ b/contracts/Folio.sol
@@ -745,7 +745,7 @@ contract Folio is
         );
 
         // Create Trusted Filler
-        filler = trustedFillerRegistry.createTrustedFiller(msg.sender, targetFiller, deploymentSalt);
+        filler = trustedFillerRegistry.createTrustedFill(msg.sender, targetFiller, deploymentSalt);
         auction.sellToken.forceApprove(address(filler), sellAmount);
 
         filler.initialize(address(this), auction.sellToken, auction.buyToken, sellAmount, buyAmount);

--- a/contracts/Folio.sol
+++ b/contracts/Folio.sol
@@ -716,12 +716,12 @@ contract Folio is
             auction.buyToken.safeTransferFrom(msg.sender, address(this), boughtAmt);
         }
 
-        uint256 buyBalAfter = auction.buyToken.balanceOf(address(this));
-        require(buyBalAfter - buyBalBefore >= boughtAmt, Folio__InsufficientBid());
+        uint256 delta = auction.buyToken.balanceOf(address(this)) - buyBalBefore;
+        require(delta >= boughtAmt, Folio__InsufficientBid());
 
         // burn any Folio token purchased in auction
         if (address(auction.buyToken) == address(this)) {
-            _burn(address(this), buyBalAfter);
+            _burn(address(this), delta);
             delete activeBidder;
         }
     }

--- a/contracts/Folio.sol
+++ b/contracts/Folio.sol
@@ -302,14 +302,6 @@ contract Folio is
         return _totalAssets();
     }
 
-    /// @return _assets
-    /// @return _amounts {tok}
-    function folio() external view returns (address[] memory _assets, uint256[] memory _amounts) {
-        require(!_reentrancyGuardEntered(), ReentrancyGuardReentrantCall());
-
-        return _toAssets(10 ** decimals(), Math.Rounding.Floor);
-    }
-
     /// @param shares {share}
     /// @return _assets
     /// @return _amounts {tok}

--- a/contracts/Folio.sol
+++ b/contracts/Folio.sol
@@ -826,7 +826,9 @@ contract Folio is
         auction.endTime = endTime;
 
         // ensure buy token is in basket since swaps can happen out-of-band
-        _addToBasket(address(auction.buyToken));
+        if (address(auction.buyToken) != address(this)) {
+            _addToBasket(address(auction.buyToken));
+        }
         emit AuctionOpened(auction.id, auction, details.availableRuns);
 
         // D18{1}

--- a/contracts/interfaces/IFolio.sol
+++ b/contracts/interfaces/IFolio.sol
@@ -73,6 +73,7 @@ interface IFolio {
     error Folio__TooManyFeeRecipients();
     error Folio__InvalidArrayLengths();
     error Folio__InvalidAuctionRuns();
+    error Folio__InvalidTransferToSelf();
 
     error Folio__TrustedFillerRegistryNotSet();
     error Folio__TrustedFillerRegistryAlreadySet();

--- a/script/Deploy.s.sol
+++ b/script/Deploy.s.sol
@@ -43,7 +43,7 @@ contract DeployScript is Script {
 
         if (block.chainid == 31337) {
             deploymentParams[31337] = DeploymentParams({
-                rsrToken: 0x89A8c847f41C0dfA6c8B88638bACca8a0b777Da7, // Garbage token that just exists on Junk Address
+                rsrToken: 0x77A251303Bb698227d2d99E9E8345D1D7F90a4C4, // Garbage token that just exists on Junk Address
                 roleRegistry: address(new MockRoleRegistry()), // Mock Registry for Local Networks
                 folioFeeRegistry: address(0),
                 feeRecipient: address(1), // Burn fees for Local Networks

--- a/script/Deploy.s.sol
+++ b/script/Deploy.s.sol
@@ -43,7 +43,7 @@ contract DeployScript is Script {
 
         if (block.chainid == 31337) {
             deploymentParams[31337] = DeploymentParams({
-                rsrToken: 0xd2877702675e6cEb975b4A1dFf9fb7BAF4C91ea9, // Garbage token that just exists on Junk Address
+                rsrToken: 0x89A8c847f41C0dfA6c8B88638bACca8a0b777Da7, // Garbage token that just exists on Junk Address
                 roleRegistry: address(new MockRoleRegistry()), // Mock Registry for Local Networks
                 folioFeeRegistry: address(0),
                 feeRecipient: address(1), // Burn fees for Local Networks

--- a/snapshots/FolioDeployerTest.json
+++ b/snapshots/FolioDeployerTest.json
@@ -1,4 +1,4 @@
 {
-  "deployFolio()": "1770471",
-  "deployGovernedFolio": "2189587"
+  "deployFolio()": "1786727",
+  "deployGovernedFolio": "2208305"
 }

--- a/snapshots/FolioTest.json
+++ b/snapshots/FolioTest.json
@@ -1,5 +1,5 @@
 {
-  "getPrice()": "2371",
-  "poke()": "84228",
-  "repeat poke()": "5370"
+  "getBid()": "60639",
+  "poke()": "90455",
+  "repeat poke()": "5566"
 }

--- a/snapshots/GovernanceDeployerTest.json
+++ b/snapshots/GovernanceDeployerTest.json
@@ -1,3 +1,3 @@
 {
-  "deployGovernedStakingToken()": "4225358"
+  "deployGovernedStakingToken()": "4142338"
 }

--- a/snapshots/StakingVaultTest.json
+++ b/snapshots/StakingVaultTest.json
@@ -1,11 +1,11 @@
 {
-  "poke with one token": "31594",
-  "poke(1, 1 tokens)": "102879",
-  "poke(1, 10 tokens)": "1021636",
-  "poke(1, 25 tokens)": "2552934",
-  "poke(1, 50 tokens)": "5105192",
-  "poke(2, 1 tokens)": "13279",
-  "poke(2, 10 tokens)": "125636",
-  "poke(2, 25 tokens)": "312934",
-  "poke(2, 50 tokens)": "625192"
+  "poke with one token": "31628",
+  "poke(1, 1 tokens)": "102913",
+  "poke(1, 10 tokens)": "1021670",
+  "poke(1, 25 tokens)": "2552968",
+  "poke(1, 50 tokens)": "5105226",
+  "poke(2, 1 tokens)": "13313",
+  "poke(2, 10 tokens)": "125670",
+  "poke(2, 25 tokens)": "312968",
+  "poke(2, 50 tokens)": "625226"
 }

--- a/test/Folio.t.sol
+++ b/test/Folio.t.sol
@@ -1448,7 +1448,7 @@ contract FolioTest is BaseTest {
 
         // bid for the full volume, at end time
         vm.startPrank(owner);
-        IBaseTrustedFiller swap2 = folio.createTrustedFiller(0, cowswapFiller, bytes32(block.timestamp));
+        IBaseTrustedFiller swap2 = folio.createTrustedFill(0, cowswapFiller, bytes32(block.timestamp));
         MockERC20(address(USDC)).burn(address(swap2), amt);
         folio.transfer(address(swap2), amt * 1e12);
         assertEq(USDC.balanceOf(address(folio)), 0, "wrong usdc balance folio");

--- a/test/Folio.t.sol
+++ b/test/Folio.t.sol
@@ -1452,9 +1452,10 @@ contract FolioTest is BaseTest {
         MockERC20(address(USDC)).burn(address(swap2), amt);
         folio.transfer(address(swap2), amt * 1e12);
         assertEq(USDC.balanceOf(address(folio)), 0, "wrong usdc balance folio");
-        assertEq(USDC.balanceOf(address(swap2)), 0, "wrong usdc balance swap");
+        assertEq(USDC.balanceOf(address(swap2)), 0, "wrong usdc balance filler");
         assertEq(folio.balanceOf(address(folio)), 0, "wrong folio balance folio");
-        assertEq(folio.balanceOf(address(swap2)), 0, "wrong folio balance swap");
+        assertEq(folio.balanceOf(address(swap2)), amt * 1e12, "wrong folio balance filler");
+        assertEq(folio.totalSupply(), 0, "should be excluded from totalSupply");
         vm.stopPrank();
 
         // anyone should be able to close, even though it's ideal this happens in the cowswap post-hook
@@ -1462,7 +1463,8 @@ contract FolioTest is BaseTest {
         assertEq(USDC.balanceOf(address(folio)), 0, "wrong usdc balance folio after close");
         assertEq(USDC.balanceOf(address(swap2)), 0, "wrong usdc balance after close");
         assertEq(folio.balanceOf(address(folio)), 0, "wrong folio balance folio after close");
-        assertEq(folio.balanceOf(address(swap2)), 0, "wrong folio balance swap after close");
+        assertEq(folio.balanceOf(address(swap2)), 0, "wrong folio balance filler after close");
+        assertEq(folio.totalSupply(), 0, "should be excluded from totalSupply after close");
     }
 
     function test_auctionIsValidSignature() public {

--- a/test/Folio.t.sol
+++ b/test/Folio.t.sol
@@ -203,57 +203,6 @@ contract FolioTest is BaseTest {
         assertEq(_amounts[2], D27_TOKEN_1 / 2, "wrong third amount");
     }
 
-    function test_toAssets_noReentrancy() public {
-        // deploy and mint reentrant token
-        MockReentrantERC20 REENTRANT = new MockReentrantERC20("REENTRANT", "REENTER", 18);
-        address[] memory actors = new address[](1);
-        actors[0] = owner;
-        uint256[] memory amounts_18 = new uint256[](1);
-        amounts_18[0] = D18_TOKEN_1M;
-        mintToken(address(REENTRANT), actors, amounts_18);
-
-        // create folio
-        address[] memory tokens = new address[](2);
-        tokens[0] = address(USDC);
-        tokens[1] = address(REENTRANT);
-        uint256[] memory amounts = new uint256[](2);
-        amounts[0] = D6_TOKEN_10K;
-        amounts[1] = D18_TOKEN_10K;
-        IFolio.FeeRecipient[] memory recipients = new IFolio.FeeRecipient[](2);
-        recipients[0] = IFolio.FeeRecipient(owner, 0.9e18);
-        recipients[1] = IFolio.FeeRecipient(feeReceiver, 0.1e18);
-
-        // 50% tvl fee annually
-        vm.startPrank(owner);
-        USDC.approve(address(folioDeployer), type(uint256).max);
-        REENTRANT.approve(address(folioDeployer), type(uint256).max);
-
-        (folio, proxyAdmin) = createFolio(
-            tokens,
-            amounts,
-            INITIAL_SUPPLY,
-            MAX_AUCTION_DELAY,
-            MAX_AUCTION_LENGTH,
-            recipients,
-            MAX_TVL_FEE,
-            0,
-            owner,
-            dao,
-            auctionLauncher
-        );
-        vm.stopPrank();
-
-        // Set reentrancy on and attempt to mint
-        REENTRANT.setReentrancy(true);
-
-        vm.startPrank(owner);
-        USDC.approve(address(folio), type(uint256).max);
-        REENTRANT.approve(address(folio), type(uint256).max);
-        vm.expectRevert(ReentrancyGuardUpgradeable.ReentrancyGuardReentrantCall.selector);
-        folio.mint(1e18, owner, 0);
-        vm.stopPrank();
-    }
-
     function test_mint() public {
         assertEq(folio.balanceOf(user1), 0, "wrong starting user1 balance");
         uint256 startingUSDCBalance = USDC.balanceOf(address(folio));

--- a/test/Folio.t.sol
+++ b/test/Folio.t.sol
@@ -1451,17 +1451,18 @@ contract FolioTest is BaseTest {
         IBaseTrustedFiller swap2 = folio.createTrustedFiller(0, cowswapFiller, bytes32(block.timestamp));
         MockERC20(address(USDC)).burn(address(swap2), amt);
         folio.transfer(address(swap2), amt * 1e12);
-        assertEq(USDC.balanceOf(address(folio)), 0, "wrong usdc balance");
+        assertEq(USDC.balanceOf(address(folio)), 0, "wrong usdc balance folio");
+        assertEq(USDC.balanceOf(address(swap2)), 0, "wrong usdc balance swap");
+        assertEq(folio.balanceOf(address(folio)), 0, "wrong folio balance folio");
+        assertEq(folio.balanceOf(address(swap2)), 0, "wrong folio balance swap");
         vm.stopPrank();
 
         // anyone should be able to close, even though it's ideal this happens in the cowswap post-hook
         swap2.closeFiller();
-        assertEq(USDC.balanceOf(address(swap2)), 0, "wrong usdc balance");
-        assertEq(folio.balanceOf(address(swap2)), 0, "wrong folio balance");
-
-        // Folio should have burnt its balance
-        assertEq(USDC.balanceOf(address(folio)), 0, "wrong folio usdc balance");
-        assertEq(folio.balanceOf(address(folio)), 0, "wrong folio folio balance");
+        assertEq(USDC.balanceOf(address(folio)), 0, "wrong usdc balance folio after close");
+        assertEq(USDC.balanceOf(address(swap2)), 0, "wrong usdc balance after close");
+        assertEq(folio.balanceOf(address(folio)), 0, "wrong folio balance folio after close");
+        assertEq(folio.balanceOf(address(swap2)), 0, "wrong folio balance swap after close");
     }
 
     function test_auctionIsValidSignature() public {

--- a/test/Folio.t.sol
+++ b/test/Folio.t.sol
@@ -178,7 +178,7 @@ contract FolioTest is BaseTest {
     }
 
     function test_getFolio() public view {
-        (address[] memory _assets, uint256[] memory _amounts) = folio.folio();
+        (address[] memory _assets, uint256[] memory _amounts) = folio.toAssets(1e18, Math.Rounding.Floor);
         assertEq(_assets.length, 3, "wrong assets length");
         assertEq(_assets[0], address(USDC), "wrong first asset");
         assertEq(_assets[1], address(DAI), "wrong second asset");
@@ -1914,7 +1914,7 @@ contract FolioTest is BaseTest {
         DAI.approve(address(folio), amt * 1e12);
         folio.bid(0, amt - 2, (amt - 2) * 1e12, false, bytes(""));
 
-        (address[] memory tripleBasket, ) = folio.folio();
+        (address[] memory tripleBasket, ) = folio.toAssets(1e18, Math.Rounding.Floor);
         assertEq(tripleBasket.length, 3);
         assertEq(tripleBasket[0], address(USDC));
         assertEq(tripleBasket[1], address(DAI));
@@ -1924,7 +1924,7 @@ contract FolioTest is BaseTest {
 
         folio.bid(0, 1, 1e12, false, bytes(""));
 
-        (address[] memory doubleBasket, ) = folio.folio();
+        (address[] memory doubleBasket, ) = folio.toAssets(1e18, Math.Rounding.Floor);
         assertEq(doubleBasket.length, 2);
         assertEq(doubleBasket[0], address(MEME)); // order reverses after removal
         assertEq(doubleBasket[1], address(DAI));


### PR DESCRIPTION
I don't disagree this is complicated...but the central conflict arises from supporting both trusted fills and buying the Folio token. The only way I think we can avoid the complexity is by NOT buying the Folio, which seems to me to be the only way to cleanly rebalance into all other assets prorata, or by forbidding trusted fills in the Folio buy case, which comes at large cost.

checked with rest of team and it shouldn't be hard to switch them over to `toAssets(1e18, 0)` instead of `folio()`.

to discuss view reentrancy guards Monday

