### PR TITLE
Multi-step rebalancing

### DIFF
--- a/contracts/utils/AuctionLib.sol
+++ b/contracts/utils/AuctionLib.sol
@@ -276,13 +276,13 @@ library AuctionLib {
     /// @return D27{sellTok/share}
     function _sellTokenPresence(uint256 balance, uint256 totalSupply) internal pure returns (uint256) {
         // D27{sellTok/share} = {sellTok} * D27 / {share}
-        return Math.mulDiv(balance, D27, totalSupply, Math.Rounding.Ceil);
+        return Math.mulDiv(balance, D27, totalSupply, Math.Rounding.Floor);
     }
 
     /// @return D27{buyTok/share}
     function _buyTokenPresence(uint256 balance, uint256 totalSupply) internal pure returns (uint256) {
         // D27{buyTok/share} = {buyTok} * D27 / {share}
-        return Math.mulDiv(balance, D27, totalSupply, Math.Rounding.Floor);
+        return Math.mulDiv(balance, D27, totalSupply, Math.Rounding.Ceil);
     }
 
     /// @return pair The hash of the pair

--- a/contracts/utils/AuctionLib.sol
+++ b/contracts/utils/AuctionLib.sol
@@ -56,7 +56,7 @@ library AuctionLib {
             auctionEnds[rebalance.nonce][pair] = block.timestamp + auctionLength;
         }
 
-        // confirm limits relative ordered
+        // validate auction limits
         require(
             args.sellLimit >= sellDetails.limits.low && args.sellLimit <= sellDetails.limits.high,
             IFolio.Folio__InvalidSellLimit()
@@ -75,7 +75,7 @@ library AuctionLib {
             IFolio.Folio__InvalidPrices()
         );
 
-        // confirm sell token is in surplus and update limits
+        // confirm sell token is in surplus and update rebalance limits
         {
             // D27{sellTok/share}
             uint256 currentSellPresence = _sellTokenPresence(args.sellToken.balanceOf(address(this)), totalSupply);
@@ -92,7 +92,7 @@ library AuctionLib {
             // leave low sell limit unchanged to allow future auctions to trade FURTHER if needed
         }
 
-        // confirm buy token is in deficit and update limits
+        // confirm buy token is in deficit and update rebalance limits
         {
             // D27{buyTok/share}
             uint256 currentBuyPresence = _buyTokenPresence(args.buyToken.balanceOf(address(this)), totalSupply);


### PR DESCRIPTION
The status quo implementation prevents the AUCTION_LAUNCHER from rebalancing purposefully in multiple steps because opening an auction updates the rebalance spot limit unilaterally. 

3 logic changes to AuctionLib.openAuction()
1. AuctionLib.openAuction() now requires the sell token be in surplus and the buy token in deficit. Previously it was possible to open auctions "on the wrong side" of the held balances. This is now disallowed
2. The rebalance spot limit only updates if the auction limit represents a _further_ trade of value than what was originally planned for, making it possible to take deliberate partial steps along the way to fully rebalanced. It's important to not change the spot limit to ensure permissionless auction launching can always be a fallback if the AUCTION_LAUNCHER goes offline or runs out of time. In the case that prices have moved in the direction where the original spot limit is now unreachable, it is okay to leave the spot limit out of reach.
3. Changes rounding for existing basket presence calculations. I think we had them flipped imo. But needs double checking