### PR TITLE
allow AUCTION_LAUNCHER to lower endPrice

### DIFF
--- a/contracts/Folio.sol
+++ b/contracts/Folio.sol
@@ -534,7 +534,7 @@ contract Folio is
                 require(
                     newPrices[i].low <= newPrices[i].high &&
                         newPrices[i].high <= MAX_TOKEN_PRICE &&
-                        newPrices[i].high / newPrices[i].low <= MAX_TOKEN_PRICE_RANGE,
+                        newPrices[i].high <= MAX_TOKEN_PRICE_RANGE * newPrices[i].low,
                     Folio__InvalidPrices()
                 );
             }

--- a/contracts/Folio.sol
+++ b/contracts/Folio.sol
@@ -589,13 +589,9 @@ contract Folio is
         if (sellDetails.prices.high != 0) {
             // D27{buyTok/sellTok} = D27 * D27{UoA/sellTok} / D27{UoA/buyTok}
             uint256 oldStartPrice = (D27 * sellDetails.prices.high + buyDetails.prices.low - 1) / buyDetails.prices.low;
-            uint256 oldEndPrice = (D27 * sellDetails.prices.low + buyDetails.prices.high - 1) / buyDetails.prices.high;
 
-            // allow up to 100x price increase
-            require(
-                startPrice >= oldStartPrice && startPrice <= 100 * oldStartPrice && endPrice >= oldEndPrice,
-                Folio__InvalidPrices()
-            );
+            require(startPrice >= oldStartPrice, Folio__InvalidPrices());
+            // AuctionLib.openAuction() will check that startPrice / endPrice <= MAX_AUCTION_PRICE_RANGE
         }
 
         // for upgraded Folios, pick up on the next auction index from the old array

--- a/contracts/Folio.sol
+++ b/contracts/Folio.sol
@@ -13,7 +13,7 @@ import { Math } from "@openzeppelin/contracts/utils/math/Math.sol";
 import { ITrustedFillerRegistry, IBaseTrustedFiller } from "@reserve-protocol/trusted-fillers/contracts/interfaces/ITrustedFillerRegistry.sol";
 
 import { AuctionLib } from "@utils/AuctionLib.sol";
-import { D18, D27, MAX_TVL_FEE, MAX_MINT_FEE, MIN_MINT_FEE, MIN_AUCTION_LENGTH, MAX_AUCTION_LENGTH, MAX_FEE_RECIPIENTS, MAX_LIMIT, MAX_TOKEN_PRICE, MAX_TOKEN_PRICE_RANGE, MAX_AUCTION_LAUNCHER_PRICE_RANGE, MAX_TTL, RESTRICTED_AUCTION_BUFFER, ONE_OVER_YEAR, ONE_DAY } from "@utils/Constants.sol";
+import { D18, D27, MAX_TVL_FEE, MAX_MINT_FEE, MIN_MINT_FEE, MIN_AUCTION_LENGTH, MAX_AUCTION_LENGTH, MAX_AUCTION_PRICE_RANGE, MAX_FEE_RECIPIENTS, MAX_LIMIT, MAX_TOKEN_PRICE, MAX_TOKEN_PRICE_RANGE, MAX_TTL, RESTRICTED_AUCTION_BUFFER, ONE_OVER_YEAR, ONE_DAY } from "@utils/Constants.sol";
 import { MathLib } from "@utils/MathLib.sol";
 import { Versioned } from "@utils/Versioned.sol";
 
@@ -591,10 +591,8 @@ contract Folio is
             uint256 oldStartPrice = (D27 * sellDetails.prices.high + buyDetails.prices.low - 1) / buyDetails.prices.low;
 
             // allow to lower the end price, but compel the auction launcher to a high startPrice
-            require(
-                startPrice >= oldStartPrice && startPrice / endPrice <= MAX_AUCTION_LAUNCHER_PRICE_RANGE,
-                Folio__InvalidPrices()
-            );
+            require(startPrice >= oldStartPrice, Folio__InvalidPrices());
+            // overall auction price range checked later
         }
 
         // for upgraded Folios, pick up on the next auction index from the old array

--- a/contracts/Folio.sol
+++ b/contracts/Folio.sol
@@ -13,7 +13,7 @@ import { Math } from "@openzeppelin/contracts/utils/math/Math.sol";
 import { ITrustedFillerRegistry, IBaseTrustedFiller } from "@reserve-protocol/trusted-fillers/contracts/interfaces/ITrustedFillerRegistry.sol";
 
 import { AuctionLib } from "@utils/AuctionLib.sol";
-import { D18, D27, MAX_TVL_FEE, MAX_MINT_FEE, MIN_MINT_FEE, MIN_AUCTION_LENGTH, MAX_AUCTION_LENGTH, MAX_FEE_RECIPIENTS, MAX_LIMIT, MAX_TOKEN_PRICE, MAX_TOKEN_PRICE_RANGE, MAX_TTL, RESTRICTED_AUCTION_BUFFER, ONE_OVER_YEAR, ONE_DAY } from "@utils/Constants.sol";
+import { D18, D27, MAX_TVL_FEE, MAX_MINT_FEE, MIN_MINT_FEE, MIN_AUCTION_LENGTH, MAX_AUCTION_LENGTH, MAX_FEE_RECIPIENTS, MAX_LIMIT, MAX_TOKEN_PRICE, MAX_TOKEN_PRICE_RANGE, MAX_AUCTION_LAUNCHER_PRICE_RANGE, MAX_TTL, RESTRICTED_AUCTION_BUFFER, ONE_OVER_YEAR, ONE_DAY } from "@utils/Constants.sol";
 import { MathLib } from "@utils/MathLib.sol";
 import { Versioned } from "@utils/Versioned.sol";
 
@@ -590,8 +590,11 @@ contract Folio is
             // D27{buyTok/sellTok} = D27 * D27{UoA/sellTok} / D27{UoA/buyTok}
             uint256 oldStartPrice = (D27 * sellDetails.prices.high + buyDetails.prices.low - 1) / buyDetails.prices.low;
 
-            require(startPrice >= oldStartPrice, Folio__InvalidPrices());
-            // AuctionLib.openAuction() will check that startPrice / endPrice <= MAX_AUCTION_PRICE_RANGE
+            // allow to lower the end price, but compel the auction launcher to a high startPrice
+            require(
+                startPrice >= oldStartPrice && startPrice / endPrice <= MAX_AUCTION_LAUNCHER_PRICE_RANGE,
+                Folio__InvalidPrices()
+            );
         }
 
         // for upgraded Folios, pick up on the next auction index from the old array

--- a/contracts/utils/Constants.sol
+++ b/contracts/utils/Constants.sol
@@ -14,7 +14,7 @@ uint256 constant MAX_TOKEN_BALANCE = 1e36; // {tok}
 uint256 constant MAX_TOKEN_PRICE = 1e36; // D27{UoA/tok}
 uint256 constant MAX_TOKEN_PRICE_RANGE = 1e2; // {1}
 uint256 constant MAX_AUCTION_PRICE = 1e63; // D27{buyTok/sellTok}
-uint256 constant MAX_AUCTION_PRICE_RANGE = 1e6; // {1}
+uint256 constant MAX_AUCTION_PRICE_RANGE = 1e4; // {1}
 uint256 constant RESTRICTED_AUCTION_BUFFER = 120; // {s} 2 min
 
 uint256 constant ONE_OVER_YEAR = 31709791983; // D18{1/s} 1e18 / 31536000

--- a/contracts/utils/Constants.sol
+++ b/contracts/utils/Constants.sol
@@ -15,6 +15,7 @@ uint256 constant MAX_TOKEN_PRICE = 1e36; // D27{UoA/tok}
 uint256 constant MAX_TOKEN_PRICE_RANGE = 1e2; // {1}
 uint256 constant MAX_AUCTION_PRICE = 1e63; // D27{buyTok/sellTok}
 uint256 constant MAX_AUCTION_PRICE_RANGE = 1e4; // {1}
+uint256 constant MAX_AUCTION_LAUNCHER_PRICE_RANGE = 1e2; // {1}
 uint256 constant RESTRICTED_AUCTION_BUFFER = 120; // {s} 2 min
 
 uint256 constant ONE_OVER_YEAR = 31709791983; // D18{1/s} 1e18 / 31536000

--- a/contracts/utils/Constants.sol
+++ b/contracts/utils/Constants.sol
@@ -15,7 +15,6 @@ uint256 constant MAX_TOKEN_PRICE = 1e36; // D27{UoA/tok}
 uint256 constant MAX_TOKEN_PRICE_RANGE = 1e2; // {1}
 uint256 constant MAX_AUCTION_PRICE = 1e63; // D27{buyTok/sellTok}
 uint256 constant MAX_AUCTION_PRICE_RANGE = 1e4; // {1}
-uint256 constant MAX_AUCTION_LAUNCHER_PRICE_RANGE = 1e2; // {1}
 uint256 constant RESTRICTED_AUCTION_BUFFER = 120; // {s} 2 min
 
 uint256 constant ONE_OVER_YEAR = 31709791983; // D18{1/s} 1e18 / 31536000

--- a/test/Folio.t.sol
+++ b/test/Folio.t.sol
@@ -1537,7 +1537,7 @@ contract FolioTest is BaseTest {
             buyToken: USDC,
             sellLimit: 0,
             buyLimit: MAX_LIMIT,
-            startPrice: 1e5,
+            startPrice: 1e4,
             endPrice: 1,
             startTime: block.timestamp,
             endTime: block.timestamp + MAX_AUCTION_DELAY
@@ -1546,19 +1546,19 @@ contract FolioTest is BaseTest {
         vm.prank(auctionLauncher);
         vm.expectEmit(true, false, false, false);
         emit IFolio.AuctionOpened(0, auctionStruct);
-        folio.openAuction(MEME, USDC, 0, MAX_LIMIT, 1e5, 1);
+        folio.openAuction(MEME, USDC, 0, MAX_LIMIT, 1e4, 1);
 
         // should have right bid at start, middle, and end of auction
 
         (, , , , , , , uint256 start, uint256 end) = folio.auctions(0);
 
         (uint256 sellAmount, uint256 buyAmount, ) = folio.getBid(0, start, amt);
-        assertEq(sellAmount, amt, "wrong start sell amount"); // 10x
-        assertEq(buyAmount, amt / 1e22, "wrong start buy amount"); // 10x
+        assertEq(sellAmount, amt, "wrong start sell amount"); // 10000x
+        assertEq(buyAmount, 1e4, "wrong start buy amount"); // 10000x
 
         (sellAmount, buyAmount, ) = folio.getBid(0, (start + end) / 2, amt);
-        assertEq(sellAmount, amt, "wrong mid sell amount"); // ~3.16x
-        assertEq(buyAmount, 316, "wrong mid buy amount"); // ~3.16x
+        assertEq(sellAmount, amt, "wrong mid sell amount"); // 100x
+        assertEq(buyAmount, 100, "wrong mid buy amount"); // 100x
 
         (sellAmount, buyAmount, ) = folio.getBid(0, end, amt);
         assertEq(sellAmount, amt, "wrong end sell amount"); // 1x


### PR DESCRIPTION
It is not actually important that the AUCTION_LAUNCHER provide an `endPrice >= oldEndPrice`: the start price of the auction is important because that's where first-block clears can happen, losing value to MEV, but the only other property we need from the auction curve is that it is not so large as to be imprecise, block-by-block. To that end, it will be possible to actually craft _better_ auctions as the AUCTION_LAUNCHER if sometimes they can go below the `oldEndPrice`, such as in cases where the expected clearing price rests just above the `oldEndPrice` but there is some ambiguity about how good liquidity is.

This PR also lowers the max auction range