### PR TITLE
spell fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,8 +33,8 @@
     "size": "forge compile --sizes",
     "coverage": "forge coverage --report lcov --no-match-coverage '(script|test)'",
     "coverage:summary": "forge coverage --report summary --no-match-coverage '(script|test)'",
-    "deploy": "forge script script/Deploy.s.sol:DeployScript --broadcast --slow",
-    "deploy:spell": "forge script script/DeploySpell.s.sol:DeploySpell --broadcast --slow",
+    "deploy": "forge script script/Deploy.s.sol:DeployScript --broadcast --slow --verify",
+    "deploy:spell": "forge script script/DeploySpell.s.sol:DeploySpell --broadcast --slow --verify",
     "playground": "forge script script/Playground.s.sol:PlaygroundScript --slow",
     "anvil": "anvil --fork-url https://ethereum-rpc.publicnode.com --chain-id 31337 --prune-history"
   },

--- a/package.json
+++ b/package.json
@@ -33,8 +33,8 @@
     "size": "forge compile --sizes",
     "coverage": "forge coverage --report lcov --no-match-coverage '(script|test)'",
     "coverage:summary": "forge coverage --report summary --no-match-coverage '(script|test)'",
-    "deploy": "forge script script/Deploy.s.sol:DeployScript --broadcast --slow --verify",
-    "deploy:spell": "forge script script/DeploySpell.s.sol:DeploySpell --broadcast --slow --verify",
+    "deploy": "forge script script/Deploy.s.sol:DeployScript --broadcast --slow",
+    "deploy:spell": "forge script script/DeploySpell.s.sol:DeploySpell --broadcast --slow",
     "playground": "forge script script/Playground.s.sol:PlaygroundScript --slow",
     "anvil": "anvil --fork-url https://ethereum-rpc.publicnode.com --chain-id 31337 --prune-history"
   },

--- a/test/spells/GovernanceSpell_31_03_2025/GenericGovernanceSpell_31_03_2025.t.sol
+++ b/test/spells/GovernanceSpell_31_03_2025/GenericGovernanceSpell_31_03_2025.t.sol
@@ -89,8 +89,16 @@ abstract contract GovernanceSpell_31_03_2025_Test is BaseTest {
             );
             assertEq(stakingVault.owner(), newStakingVaultGovernor.timelock());
 
-            assertEq(newStakingVaultGovernor.votingDelay(), stakingVaultGovernor.votingDelay());
-            assertEq(newStakingVaultGovernor.votingPeriod(), stakingVaultGovernor.votingPeriod());
+            uint256 periodMultiplier = 24;
+            if (
+                address(stakingVaultGovernor) == spell.ABX_GOVERNOR() ||
+                address(stakingVaultGovernor) == spell.AI_GOVERNOR()
+            ) {
+                periodMultiplier = 1;
+            }
+
+            assertEq(newStakingVaultGovernor.votingDelay(), stakingVaultGovernor.votingDelay() * periodMultiplier);
+            assertEq(newStakingVaultGovernor.votingPeriod(), stakingVaultGovernor.votingPeriod() * periodMultiplier);
             assertEq(newStakingVaultGovernor.quorumNumerator(), stakingVaultGovernor.quorumNumerator() * 1e16);
             assertEq(newStakingVaultGovernor.quorumDenominator(), stakingVaultGovernor.quorumDenominator() * 1e16);
             assertApproxEqAbs(
@@ -101,7 +109,7 @@ abstract contract GovernanceSpell_31_03_2025_Test is BaseTest {
             );
             assertEq(
                 TimelockController(payable(newStakingVaultGovernor.timelock())).getMinDelay(),
-                TimelockController(payable(stakingVaultGovernor.timelock())).getMinDelay()
+                TimelockController(payable(stakingVaultGovernor.timelock())).getMinDelay() * periodMultiplier
             );
 
             // folio

--- a/test/spells/GovernanceSpell_31_03_2025/GenericGovernanceSpell_31_03_2025.t.sol
+++ b/test/spells/GovernanceSpell_31_03_2025/GenericGovernanceSpell_31_03_2025.t.sol
@@ -124,6 +124,13 @@ abstract contract GovernanceSpell_31_03_2025_Test is BaseTest {
                     executionDelayPeriodMultiplier
             );
 
+            console2.log("daoGovernor.votingDelay()", newStakingVaultGovernor.votingDelay());
+            console2.log("daoGovernor.votingPeriod()", newStakingVaultGovernor.votingPeriod());
+            console2.log(
+                "daoGovernor.executionDelay()",
+                TimelockController(payable(newStakingVaultGovernor.timelock())).getMinDelay()
+            );
+
             // folio
 
             vm.startPrank(address(ownerTimelock));
@@ -169,6 +176,13 @@ abstract contract GovernanceSpell_31_03_2025_Test is BaseTest {
                 TimelockController(payable(ownerGovernor.timelock())).getMinDelay()
             );
 
+            console2.log("ownerGovernor.votingDelay()", newOwnerGovernor.votingDelay());
+            console2.log("ownerGovernor.votingPeriod()", newOwnerGovernor.votingPeriod());
+            console2.log(
+                "ownerTimelock.executionDelay()",
+                TimelockController(payable(newOwnerGovernor.timelock())).getMinDelay()
+            );
+
             assertEq(newTradingGovernor.votingDelay(), tradingGovernor.votingDelay());
             assertEq(newTradingGovernor.votingPeriod(), tradingGovernor.votingPeriod());
             assertEq(newTradingGovernor.quorumNumerator(), tradingGovernor.quorumNumerator() * 1e16);
@@ -182,6 +196,13 @@ abstract contract GovernanceSpell_31_03_2025_Test is BaseTest {
             assertEq(
                 TimelockController(payable(newTradingGovernor.timelock())).getMinDelay(),
                 TimelockController(payable(tradingGovernor.timelock())).getMinDelay()
+            );
+
+            console2.log("tradingGovernor.votingDelay()", newTradingGovernor.votingDelay());
+            console2.log("tradingGovernor.votingPeriod()", newTradingGovernor.votingPeriod());
+            console2.log(
+                "tradingTimelock.executionDelay()",
+                TimelockController(payable(newTradingGovernor.timelock())).getMinDelay()
             );
 
             // post-fork proposal


### PR DESCRIPTION
SHOULD
- maintain quorum ratio, just converting 1-100 to 1-1e18
- divide proposalThreshold by 100 for all _trading_ governors
- multiply stakingVault governor periods by 24 uniformly, except for the 3 exception DTFs (ABX / CLX / AI)

(had to move some sections of code around to deal with stack-too-deep stuff)