### PR TITLE
Configure dependency install policy

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,5 @@
+minimumReleaseAge: 10080
+blockExoticSubdeps: true
+
 overrides:
   "@reserve-protocol/reserve-index-dtf": "file:./"


### PR DESCRIPTION
## Summary
- Set pnpm minimumReleaseAge to 10080 minutes (7 days)
- Enable pnpm blockExoticSubdeps

## Verification
- pnpm config get minimumReleaseAge -> 10080
- pnpm config get blockExoticSubdeps -> true