### PR TITLE
Document Folio version registry lifecycle

### DIFF
--- a/contracts/folio/FolioVersionRegistry.sol
+++ b/contracts/folio/FolioVersionRegistry.sol
@@ -13,8 +13,7 @@ import { Versioned } from "@utils/Versioned.sol";
  * @notice FolioVersionRegistry tracks Folio deployments by their version string
  * @dev Operationally, old Folio versions should be deprecated as new versions are registered.
  *      Keeping only one non-deprecated version live at a time limits downgrade paths and reduces
- *      the chance that governance or callers select stale Folio implementations, unless a rollout
- *      intentionally overlaps versions.
+ *      the chance that governance or callers select stale Folio implementations.
  */
 contract FolioVersionRegistry is IFolioVersionRegistry {
     IRoleRegistry public immutable roleRegistry;

--- a/contracts/folio/FolioVersionRegistry.sol
+++ b/contracts/folio/FolioVersionRegistry.sol
@@ -12,8 +12,9 @@ import { Versioned } from "@utils/Versioned.sol";
  * @author akshatmittal, julianmrodri, pmckelvy1, tbrent
  * @notice FolioVersionRegistry tracks Folio deployments by their version string
  * @dev Operationally, old Folio versions should be deprecated as new versions are registered.
- *      Keeping only one non-deprecated version live at a time reduces the risk of governance
- *      intentionally or accidentally deploying new Folios on stale implementations.
+ *      Keeping only one non-deprecated version live at a time limits downgrade paths and reduces
+ *      the chance that governance or callers select stale Folio implementations, unless a rollout
+ *      intentionally overlaps versions.
  */
 contract FolioVersionRegistry is IFolioVersionRegistry {
     IRoleRegistry public immutable roleRegistry;

--- a/contracts/folio/FolioVersionRegistry.sol
+++ b/contracts/folio/FolioVersionRegistry.sol
@@ -11,6 +11,9 @@ import { Versioned } from "@utils/Versioned.sol";
  * @title FolioVersionRegistry
  * @author akshatmittal, julianmrodri, pmckelvy1, tbrent
  * @notice FolioVersionRegistry tracks Folio deployments by their version string
+ * @dev Operationally, old Folio versions should be deprecated as new versions are registered.
+ *      Keeping only one non-deprecated version live at a time reduces the risk of governance
+ *      intentionally or accidentally deploying new Folios on stale implementations.
  */
 contract FolioVersionRegistry is IFolioVersionRegistry {
     IRoleRegistry public immutable roleRegistry;
@@ -25,6 +28,9 @@ contract FolioVersionRegistry is IFolioVersionRegistry {
         roleRegistry = _roleRegistry;
     }
 
+    /// @dev Registering a new version does not automatically deprecate the previous version.
+    ///      Registry owners should deprecate old versions after registering replacements so
+    ///      getLatestVersion() is generally the only non-deprecated Folio version.
     function registerVersion(IFolioDeployer folioDeployer) external {
         require(roleRegistry.isOwner(msg.sender), VersionRegistry__InvalidCaller());
 


### PR DESCRIPTION
## Summary
- document expected Folio version registry lifecycle
- call out that older versions should be unregistered/deprecated after replacement
- clarify that deployments should generally keep only one live version unless an explicit rollout needs overlap

## Verification
- `pnpm format:check`
- `pnpm compile`
- `forge test --match-contract FolioVersionRegistryTest -vv`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated NatSpec/dev guidance for version registration and deprecation management, clarifying that registering a new version doesn’t automatically deprecate existing ones and encouraging safe deployment practices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->