### PR TITLE
Track trusted fill sell amount in Folio

### DIFF
--- a/contracts/Folio.sol
+++ b/contracts/Folio.sol
@@ -192,8 +192,12 @@ contract Folio is
 
     uint256 public folioFeeForSelf; // D18{1} fraction of fee-recipient shares to burn
 
-    uint256 private activeTrustedFillFloorPrice; // D27{buyTok/sellTok}
-    uint256 private activeTrustedFillSellAmount; // {sellTok}
+    struct ActiveTrustedFillInfo {
+        uint256 floorPrice; // D27{buyTok/sellTok}
+        uint256 sellAmount; // {sellTok}
+    }
+
+    ActiveTrustedFillInfo private activeTrustedFillInfo;
 
     /// Any external call to the Folio that relies on accurate share accounting must pre-hook poke
     modifier sync() {
@@ -844,8 +848,8 @@ contract Folio is
         filler.initialize(address(this), sellToken, buyToken, sellAmount, buyAmount);
 
         // D27{buyTok/sellTok} = {buyTok} * D27 / {sellTok}
-        activeTrustedFillFloorPrice = Math.max(1, Math.mulDiv(buyAmount, D27, sellAmount, Math.Rounding.Floor));
-        activeTrustedFillSellAmount = sellAmount;
+        activeTrustedFillInfo.floorPrice = Math.max(1, Math.mulDiv(buyAmount, D27, sellAmount, Math.Rounding.Floor));
+        activeTrustedFillInfo.sellAmount = sellAmount;
         activeTrustedFill = filler;
 
         emit AuctionTrustedFillCreated(auctionId, address(filler));
@@ -1163,14 +1167,14 @@ contract Folio is
                 (uint256 sold, uint256 bought, bool shouldRemoveFromBasket) = RebalancingLib.closeTrustedFill(
                     auctions[nextAuctionId - 1],
                     activeTrustedFill,
-                    activeTrustedFillSellAmount
+                    activeTrustedFillInfo.sellAmount
                 );
 
                 // circuit breaker
                 if (
                     trustedFillerEnabled &&
                     sold != 0 &&
-                    Math.mulDiv(bought, D27, sold, Math.Rounding.Ceil) < activeTrustedFillFloorPrice
+                    Math.mulDiv(bought, D27, sold, Math.Rounding.Ceil) < activeTrustedFillInfo.floorPrice
                     // round in-favor of no false positives
                 ) {
                     _setTrustedFillerRegistry(address(trustedFillerRegistry), false);
@@ -1180,7 +1184,7 @@ contract Folio is
                         address(activeTrustedFill),
                         sold,
                         bought,
-                        activeTrustedFillFloorPrice
+                        activeTrustedFillInfo.floorPrice
                     );
                 }
 
@@ -1192,8 +1196,7 @@ contract Folio is
             }
 
             delete activeTrustedFill;
-            delete activeTrustedFillFloorPrice;
-            delete activeTrustedFillSellAmount;
+            delete activeTrustedFillInfo;
         }
     }
 

--- a/contracts/Folio.sol
+++ b/contracts/Folio.sol
@@ -193,6 +193,7 @@ contract Folio is
     uint256 public folioFeeForSelf; // D18{1} fraction of fee-recipient shares to burn
 
     uint256 private activeTrustedFillFloorPrice; // D27{buyTok/sellTok}
+    uint256 private activeTrustedFillSellAmount; // {sellTok}
 
     /// Any external call to the Folio that relies on accurate share accounting must pre-hook poke
     modifier sync() {
@@ -844,6 +845,7 @@ contract Folio is
 
         // D27{buyTok/sellTok} = {buyTok} * D27 / {sellTok}
         activeTrustedFillFloorPrice = Math.max(1, Math.mulDiv(buyAmount, D27, sellAmount, Math.Rounding.Floor));
+        activeTrustedFillSellAmount = sellAmount;
         activeTrustedFill = filler;
 
         emit AuctionTrustedFillCreated(auctionId, address(filler));
@@ -1160,7 +1162,8 @@ contract Folio is
             if (!_emergency) {
                 (uint256 sold, uint256 bought, bool shouldRemoveFromBasket) = RebalancingLib.closeTrustedFill(
                     auctions[nextAuctionId - 1],
-                    activeTrustedFill
+                    activeTrustedFill,
+                    activeTrustedFillSellAmount
                 );
 
                 // circuit breaker
@@ -1190,6 +1193,7 @@ contract Folio is
 
             delete activeTrustedFill;
             delete activeTrustedFillFloorPrice;
+            delete activeTrustedFillSellAmount;
         }
     }
 

--- a/contracts/Folio.sol
+++ b/contracts/Folio.sol
@@ -192,11 +192,6 @@ contract Folio is
 
     uint256 public folioFeeForSelf; // D18{1} fraction of fee-recipient shares to burn
 
-    struct ActiveTrustedFillInfo {
-        uint256 floorPrice; // D27{buyTok/sellTok}
-        uint256 sellAmount; // {sellTok}
-    }
-
     ActiveTrustedFillInfo private activeTrustedFillInfo;
 
     /// Any external call to the Folio that relies on accurate share accounting must pre-hook poke
@@ -1164,28 +1159,17 @@ contract Folio is
     function _closeTrustedFill(bool _emergency) internal {
         if (address(activeTrustedFill) != address(0)) {
             if (!_emergency) {
-                (uint256 sold, uint256 bought, bool shouldRemoveFromBasket) = RebalancingLib.closeTrustedFill(
-                    auctions[nextAuctionId - 1],
-                    activeTrustedFill,
-                    activeTrustedFillInfo.sellAmount
-                );
-
-                // circuit breaker
-                if (
-                    trustedFillerEnabled &&
-                    sold != 0 &&
-                    Math.mulDiv(bought, D27, sold, Math.Rounding.Ceil) < activeTrustedFillInfo.floorPrice
-                    // round in-favor of no false positives
-                ) {
-                    _setTrustedFillerRegistry(address(trustedFillerRegistry), false);
-
-                    emit TrustedFillCircuitBreakerTriggered(
+                (bool shouldRemoveFromBasket, bool shouldDisableTrustedFillerRegistry) = RebalancingLib
+                    .closeTrustedFill(
+                        auctions[nextAuctionId - 1],
                         nextAuctionId - 1,
-                        address(activeTrustedFill),
-                        sold,
-                        bought,
-                        activeTrustedFillInfo.floorPrice
+                        activeTrustedFill,
+                        activeTrustedFillInfo,
+                        trustedFillerEnabled
                     );
+
+                if (shouldDisableTrustedFillerRegistry) {
+                    _setTrustedFillerRegistry(address(trustedFillerRegistry), false);
                 }
 
                 if (shouldRemoveFromBasket) {

--- a/contracts/interfaces/IFolio.sol
+++ b/contracts/interfaces/IFolio.sol
@@ -213,6 +213,12 @@ interface IFolio {
         mapping(address token => uint256) traded; // {tok}
     }
 
+    /// Active trusted fill details (storage)
+    struct ActiveTrustedFillInfo {
+        uint256 floorPrice; // D27{buyTok/sellTok}
+        uint256 sellAmount; // {sellTok}
+    }
+
     /// Used to mark old storage slots now deprecated
     struct DeprecatedStruct {
         bytes32 EMPTY;

--- a/contracts/utils/RebalancingLib.sol
+++ b/contracts/utils/RebalancingLib.sol
@@ -387,41 +387,66 @@ library RebalancingLib {
 
     /// Close a trusted fill
     /// @param auction The current ongoing auction
+    /// @param auctionId The current ongoing auction id
     /// @param activeTrustedFill The active trusted fill to close
-    /// @param activeTrustedFillSellAmount The sell amount recorded by Folio when the fill was created
-    /// @return sold {sellTok} The amount of sell tokens sold by the trusted fill
-    /// @return bought {buyTok} The amount of buy tokens bought by the trusted fill
+    /// @param activeTrustedFillInfo The trusted fill metadata recorded by Folio when the fill was created
+    /// @param trustedFillerEnabled Whether the trusted filler registry is currently enabled
     /// @return shouldRemoveFromBasket If true, the auction's sell token should be removed from the basket after close
+    /// @return shouldDisableTrustedFillerRegistry If true, the trusted filler registry should be disabled
     function closeTrustedFill(
         IFolio.Auction storage auction,
+        uint256 auctionId,
         IBaseTrustedFiller activeTrustedFill,
-        uint256 activeTrustedFillSellAmount
-    ) external returns (uint256 sold, uint256 bought, bool shouldRemoveFromBasket) {
+        IFolio.ActiveTrustedFillInfo storage activeTrustedFillInfo,
+        bool trustedFillerEnabled
+    ) external returns (bool shouldRemoveFromBasket, bool shouldDisableTrustedFillerRegistry) {
         IERC20 sellToken = activeTrustedFill.sellToken();
         IERC20 buyToken = activeTrustedFill.buyToken();
 
-        uint256 sellBalBefore = sellToken.balanceOf(address(this)); // {sellTok}
-        uint256 buyBalBefore = buyToken.balanceOf(address(this)); // {buyTok}
+        uint256 sellBalAfter;
+        uint256 sold;
+        uint256 bought;
 
-        activeTrustedFill.closeFiller();
+        {
+            uint256 sellBalBefore = sellToken.balanceOf(address(this)); // {sellTok}
+            uint256 buyBalBefore = buyToken.balanceOf(address(this)); // {buyTok}
 
-        // {sellTok}
-        uint256 sellBalAfter = sellToken.balanceOf(address(this));
-        uint256 sellReturned = sellBalAfter > sellBalBefore ? sellBalAfter - sellBalBefore : 0;
+            activeTrustedFill.closeFiller();
 
-        sold = activeTrustedFillSellAmount > sellReturned ? activeTrustedFillSellAmount - sellReturned : 0;
+            // {sellTok}
+            sellBalAfter = sellToken.balanceOf(address(this));
+            uint256 sellReturned = sellBalAfter > sellBalBefore ? sellBalAfter - sellBalBefore : 0;
 
-        // {buyTok}
-        uint256 buyBalAfter = buyToken.balanceOf(address(this));
-        bought = buyBalAfter > buyBalBefore ? buyBalAfter - buyBalBefore : 0;
+            sold = activeTrustedFillInfo.sellAmount > sellReturned
+                ? activeTrustedFillInfo.sellAmount - sellReturned
+                : 0;
+
+            // {buyTok}
+            uint256 buyBalAfter = buyToken.balanceOf(address(this));
+            bought = buyBalAfter > buyBalBefore ? buyBalAfter - buyBalBefore : 0;
+        }
 
         // track traded amts
         auction.traded[address(sellToken)] += sold;
         auction.traded[address(buyToken)] += bought;
 
-        // no event, cannot rely on executing in same block as fill occurred
+        // no AuctionBid event, cannot rely on executing in same block as fill occurred
 
-        return (sold, bought, sellBalAfter == 0);
+        shouldDisableTrustedFillerRegistry =
+            trustedFillerEnabled &&
+            sold != 0 &&
+            Math.mulDiv(bought, D27, sold, Math.Rounding.Ceil) < activeTrustedFillInfo.floorPrice;
+        if (shouldDisableTrustedFillerRegistry) {
+            emit IFolio.TrustedFillCircuitBreakerTriggered(
+                auctionId,
+                address(activeTrustedFill),
+                sold,
+                bought,
+                activeTrustedFillInfo.floorPrice
+            );
+        }
+
+        return (sellBalAfter == 0, shouldDisableTrustedFillerRegistry);
     }
 
     // ==== Internal ====

--- a/contracts/utils/RebalancingLib.sol
+++ b/contracts/utils/RebalancingLib.sol
@@ -388,12 +388,14 @@ library RebalancingLib {
     /// Close a trusted fill
     /// @param auction The current ongoing auction
     /// @param activeTrustedFill The active trusted fill to close
+    /// @param activeTrustedFillSellAmount The sell amount recorded by Folio when the fill was created
     /// @return sold {sellTok} The amount of sell tokens sold by the trusted fill
     /// @return bought {buyTok} The amount of buy tokens bought by the trusted fill
     /// @return shouldRemoveFromBasket If true, the auction's sell token should be removed from the basket after close
     function closeTrustedFill(
         IFolio.Auction storage auction,
-        IBaseTrustedFiller activeTrustedFill
+        IBaseTrustedFiller activeTrustedFill,
+        uint256 activeTrustedFillSellAmount
     ) external returns (uint256 sold, uint256 bought, bool shouldRemoveFromBasket) {
         IERC20 sellToken = activeTrustedFill.sellToken();
         IERC20 buyToken = activeTrustedFill.buyToken();
@@ -407,9 +409,7 @@ library RebalancingLib {
         uint256 sellBalAfter = sellToken.balanceOf(address(this));
         uint256 sellReturned = sellBalAfter > sellBalBefore ? sellBalAfter - sellBalBefore : 0;
 
-        // {sellTok}
-        uint256 sellAmount = activeTrustedFill.sellAmount();
-        sold = sellAmount > sellReturned ? sellAmount - sellReturned : 0;
+        sold = activeTrustedFillSellAmount > sellReturned ? activeTrustedFillSellAmount - sellReturned : 0;
 
         // {buyTok}
         uint256 buyBalAfter = buyToken.balanceOf(address(this));

--- a/test/Folio.t.sol
+++ b/test/Folio.t.sol
@@ -15,6 +15,7 @@ import { ITransparentUpgradeableProxy } from "@openzeppelin/contracts/proxy/tran
 import { FolioDeployerV2 } from "test/utils/upgrades/FolioDeployerV2.sol";
 import { MockEIP712 } from "test/utils/MockEIP712.sol";
 import { MockDonatingBidder } from "test/utils/MockDonatingBidder.sol";
+import { MockDishonestTrustedFiller } from "utils/MockDishonestTrustedFiller.sol";
 import { MockBidder } from "utils/MockBidder.sol";
 import "./base/BaseTest.sol";
 
@@ -1928,6 +1929,43 @@ contract FolioTest is BaseTest {
             bidBuyAmount,
             "bid should still succeed"
         );
+    }
+
+    function test_trustedFillCircuitBreakerUsesStoredSellAmount() public {
+        uint256 amt = D6_TOKEN_10K;
+
+        _openTrustedFillAuction();
+
+        MockDishonestTrustedFiller dishonestFiller = new MockDishonestTrustedFiller();
+        trustedFillerRegistry.addTrustedFiller(dishonestFiller);
+
+        (uint256 fillSellAmount, uint256 fillBuyAmount, ) = folio.getBid(0, USDC, IERC20(address(USDT)), amt);
+
+        IBaseTrustedFiller fill = folio.createTrustedFill(
+            0,
+            USDC,
+            IERC20(address(USDT)),
+            address(dishonestFiller),
+            bytes32(block.timestamp)
+        );
+        assertEq(fill.sellAmount(), 0, "dishonest filler should report zero sell amount");
+
+        uint256 sold = fillSellAmount / 2;
+        uint256 bought = Math.mulDiv(sold, fillBuyAmount, fillSellAmount, Math.Rounding.Ceil) - 1;
+        uint256 floorPrice = Math.mulDiv(fillBuyAmount, D27, fillSellAmount, Math.Rounding.Ceil);
+
+        MockERC20(address(USDC)).burn(address(fill), sold);
+        MockERC20(address(USDT)).mint(address(fill), bought);
+
+        vm.roll(block.number + 1);
+
+        vm.expectEmit(false, false, false, true, address(folio));
+        emit IFolio.TrustedFillerRegistrySet(address(trustedFillerRegistry), false);
+        vm.expectEmit(true, true, true, true, address(folio));
+        emit IFolio.TrustedFillCircuitBreakerTriggered(0, address(fill), sold, bought, floorPrice);
+        folio.poke();
+
+        assertFalse(folio.trustedFillerEnabled(), "trusted fills should be disabled");
     }
 
     function test_trustedFillAtFloorDoesNotTriggerCircuitBreaker() public {

--- a/test/Folio.t.sol
+++ b/test/Folio.t.sol
@@ -1909,10 +1909,10 @@ contract FolioTest is BaseTest {
 
         vm.roll(block.number + 1);
 
-        vm.expectEmit(false, false, false, true, address(folio));
-        emit IFolio.TrustedFillerRegistrySet(address(trustedFillerRegistry), false);
         vm.expectEmit(true, true, true, true, address(folio));
         emit IFolio.TrustedFillCircuitBreakerTriggered(0, address(fill), sold, bought, floorPrice);
+        vm.expectEmit(false, false, false, true, address(folio));
+        emit IFolio.TrustedFillerRegistrySet(address(trustedFillerRegistry), false);
         folio.poke();
 
         assertFalse(folio.trustedFillerEnabled(), "trusted fills should be disabled");
@@ -1959,10 +1959,10 @@ contract FolioTest is BaseTest {
 
         vm.roll(block.number + 1);
 
-        vm.expectEmit(false, false, false, true, address(folio));
-        emit IFolio.TrustedFillerRegistrySet(address(trustedFillerRegistry), false);
         vm.expectEmit(true, true, true, true, address(folio));
         emit IFolio.TrustedFillCircuitBreakerTriggered(0, address(fill), sold, bought, floorPrice);
+        vm.expectEmit(false, false, false, true, address(folio));
+        emit IFolio.TrustedFillerRegistrySet(address(trustedFillerRegistry), false);
         folio.poke();
 
         assertFalse(folio.trustedFillerEnabled(), "trusted fills should be disabled");

--- a/test/utils/MockDishonestTrustedFiller.sol
+++ b/test/utils/MockDishonestTrustedFiller.sol
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.28;
+
+import { IBaseTrustedFiller } from "@reserve-protocol/trusted-fillers/contracts/interfaces/IBaseTrustedFiller.sol";
+import { IERC20, SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+
+contract MockDishonestTrustedFiller is IBaseTrustedFiller {
+    using SafeERC20 for IERC20;
+
+    address public fillCreator;
+    IERC20 public sellToken;
+    IERC20 public buyToken;
+
+    uint256 public reportedSellAmount;
+    bool public isClosed;
+
+    modifier onlyFillCreator() {
+        require(msg.sender == fillCreator, "unauthorized");
+        _;
+    }
+
+    function initialize(
+        address _creator,
+        IERC20 _sellToken,
+        IERC20 _buyToken,
+        uint256 _sellAmount,
+        uint256
+    ) external {
+        require(fillCreator == address(0), "already initialized");
+
+        fillCreator = _creator;
+        sellToken = _sellToken;
+        buyToken = _buyToken;
+
+        _sellToken.safeTransferFrom(_creator, address(this), _sellAmount);
+    }
+
+    function version() external pure returns (uint256) {
+        return 2;
+    }
+
+    function sellAmount() external view returns (uint256) {
+        return reportedSellAmount;
+    }
+
+    function swapActive() external pure returns (bool) {
+        return false;
+    }
+
+    function closeFiller() external onlyFillCreator {
+        _closeFiller();
+    }
+
+    function emergencyCloseFiller() external onlyFillCreator {
+        _closeFiller();
+    }
+
+    function rescueToken(IERC20 token) external {
+        require(isClosed, "not closed");
+        _rescueToken(token);
+    }
+
+    function setPartiallyFillable(bool) external pure {}
+
+    function isValidSignature(bytes32, bytes calldata) external pure returns (bytes4) {
+        return this.isValidSignature.selector;
+    }
+
+    function _closeFiller() internal {
+        isClosed = true;
+        _rescueToken(sellToken);
+        _rescueToken(buyToken);
+    }
+
+    function _rescueToken(IERC20 token) internal {
+        uint256 tokenBalance = token.balanceOf(address(this));
+        if (tokenBalance != 0) {
+            token.safeTransfer(fillCreator, tokenBalance);
+        }
+    }
+}

--- a/test/utils/MockDishonestTrustedFiller.sol
+++ b/test/utils/MockDishonestTrustedFiller.sol
@@ -19,13 +19,7 @@ contract MockDishonestTrustedFiller is IBaseTrustedFiller {
         _;
     }
 
-    function initialize(
-        address _creator,
-        IERC20 _sellToken,
-        IERC20 _buyToken,
-        uint256 _sellAmount,
-        uint256
-    ) external {
+    function initialize(address _creator, IERC20 _sellToken, IERC20 _buyToken, uint256 _sellAmount, uint256) external {
         require(fillCreator == address(0), "already initialized");
 
         fillCreator = _creator;


### PR DESCRIPTION
## Summary

- Store the active trusted fill sell amount in Folio storage when creating the fill.
- Use the stored sell amount when closing trusted fills instead of trusting `activeTrustedFill.sellAmount()`.
- Keep active trusted-fill floor price and sell amount together in `IFolio.ActiveTrustedFillInfo`.
- Move trusted-fill circuit-breaker evaluation and trigger-event emission into `RebalancingLib.closeTrustedFill`; Folio only applies the returned registry-disable flag.
- Add a dishonest trusted filler regression test that reports zero sell amount while the circuit breaker still accounts for the real stored amount.

## Storage

- Replaces the active trusted-fill floor price field with `activeTrustedFillInfo`, whose first member is `floorPrice` and second member is `sellAmount`.
- Verified with `forge inspect contracts/Folio.sol:Folio storage-layout`; the struct starts at slot 36 and spans 64 bytes, preserving floor price at slot 36 and adding sell amount at slot 37.

## Tests

- `forge test --match-test 'test_trustedFill'`
- `forge test --no-match-test extreme`
- `pnpm format:check`