### PR TITLE
6.0.0 informational

### DIFF
--- a/contracts/Folio.sol
+++ b/contracts/Folio.sol
@@ -889,6 +889,7 @@ contract Folio is
 
     /// Close fill attempting to claw assets back, but always close fill
     /// @dev Callable by ADMIN
+    /// @dev Clawed-back token balances will not be reflected in maxAuctionSize tracking
     function emergencyCloseTrustedFill() external onlyRole(DEFAULT_ADMIN_ROLE) nonReentrant {
         _closeTrustedFill(true);
     }

--- a/contracts/Folio.sol
+++ b/contracts/Folio.sol
@@ -576,6 +576,7 @@ contract Folio is
 
     /// Get the currently ongoing rebalance
     /// @dev Nonzero return values do not imply a rebalance is ongoing; check `rebalance.availableUntil`
+    /// @dev Tokens for which inRebalance is false will contain zero weights, prices, and maxAuctionSize
     /// @return nonce The current rebalance nonce
     /// @return priceControl How much price control the AUCTION_LAUNCHER has: [NONE, PARTIAL, ATOMIC_SWAP]
     /// @return tokens The rebalance parameters for each token in the basket

--- a/contracts/Folio.sol
+++ b/contracts/Folio.sol
@@ -387,6 +387,7 @@ contract Folio is
     }
 
     /// Remove tokens from the allowlist
+    /// @dev Does not impact ongoing rebalances. Consider calling endRebalance()
     /// @param tokens The tokens to remove from the allowlist
     function removeFromAllowlist(address[] calldata tokens) external onlyRole(DEFAULT_ADMIN_ROLE) {
         uint256 len = tokens.length;

--- a/contracts/periphery/FolioLens.sol
+++ b/contracts/periphery/FolioLens.sol
@@ -97,7 +97,7 @@ contract FolioLens is Versioned {
         }
     }
 
-    /// Get all surplus and deficit balances at the given sell and buy limits
+    /// Get all surplus and deficit balances at the given sell and buy limits for the current rebalance
     /// @param sellLimit D18{BU/share} A sell limit of the rebalance
     /// @param buyLimit D18{BU/share} A buy limit of the rebalance
     function surplusesAndDeficits(
@@ -117,6 +117,10 @@ contract FolioLens is Versioned {
         deficits = new uint256[](len);
 
         for (uint256 i = 0; i < len; i++) {
+            if (!tokenParams[i].inRebalance) {
+                continue;
+            }
+
             address token = tokenParams[i].token;
 
             tokens[i] = token;

--- a/test/FolioLens.t.sol
+++ b/test/FolioLens.t.sol
@@ -69,6 +69,30 @@ contract FolioLensTest is BaseTest {
         assertEq(deficits[1], 0);
     }
 
+    function test_surplusesAndDeficits_skipsTokensNotInRebalance() public {
+        IFolio.WeightRange[] memory weights = _balancedWeights();
+        IFolio.PriceRange[] memory prices = _prices();
+
+        IFolio.TokenRebalanceParams[] memory rebalanceTokens = new IFolio.TokenRebalanceParams[](3);
+        rebalanceTokens[0] = IFolio.TokenRebalanceParams(address(USDC), weights[0], prices[0], type(uint256).max, true);
+        rebalanceTokens[1] = IFolio.TokenRebalanceParams(address(DAI), weights[1], prices[1], type(uint256).max, true);
+        rebalanceTokens[2] = IFolio.TokenRebalanceParams(address(USDT), weights[0], prices[0], type(uint256).max, true);
+        startRebalance(folio, rebalanceTokens, _limits(), 0, MAX_TTL);
+        _startBalancedRebalance();
+
+        (address[] memory tokens, uint256[] memory surpluses, uint256[] memory deficits) = lens.surplusesAndDeficits(
+            folio,
+            D18,
+            D18
+        );
+
+        assertEq(tokens[0], address(USDC));
+        assertEq(tokens[1], address(DAI));
+        assertEq(tokens[2], address(0));
+        assertEq(surpluses[2], 0);
+        assertEq(deficits[2], 0);
+    }
+
     function test_getAllBids() public {
         _startSellUsdcRebalance();
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated rebalance reporting so tokens not currently in the active rebalance are ignored and their corresponding surplus/deficit values remain zero.

* **Documentation**
  * Clarified rebalance and auction-related explanations, including allowlist removal behavior, `getRebalance()` zeroed outputs for non-rebalance basket tokens, and how auction `maxAuctionSize` tracking treats clawed-back balances.

* **Tests**
  * Added coverage to confirm `surplusesAndDeficits` skips tokens not included in the folio’s active rebalance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->