### PR TITLE
platform fee to 33%/10 bps

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ Folios support two types of fees. Both have a DAO portion that works the same un
 
 **Per-unit time fee on AUM**
 
-The DAO takes a cut with a chain-specific minimum floor. The default floor is 15 bps annually on Ethereum and Base, and 10 bps annually on BNB Smart Chain. A consequence of this is that the Folio inflates by at least the applicable floor while the floor is nonzero. If the TVL fee is set at or below the floor, then 100% of this inflation goes towards the DAO.
+The DAO takes a cut with a minimum floor of 10 bps annually. A consequence of this is that the Folio inflates by at least the floor while the floor is nonzero. If the TVL fee is set at or below the floor, then 100% of this inflation goes towards the DAO.
 
 Max: 10% annually
 
@@ -179,13 +179,13 @@ Max: 10% annually
 
 **Fee on mints**
 
-The DAO takes a cut with a chain-specific minimum floor. The DAO always receives at least the applicable floor of the value of the mint. If the mint fee is set at or below the floor, then 100% of the mint fee is taken by the DAO.
+The DAO takes a cut with a minimum floor of 10 bps. The DAO always receives at least the floor of the value of the mint. If the mint fee is set at or below the floor, then 100% of the mint fee is taken by the DAO.
 
 Max: 5%
 
 #### Fee Floor
 
-The chain-specific default fee floor is capped by the DAO. Per-Folio fee floors can also be set, but they cannot exceed the default floor.
+The default 10 bps fee floor is capped by the DAO. Per-Folio fee floors can also be set, but they cannot exceed the default floor.
 
 ### Units
 

--- a/contracts/Folio.sol
+++ b/contracts/Folio.sol
@@ -84,7 +84,7 @@ import { IFolio } from "@interfaces/IFolio.sol";
  *   - Mint fee: fee on mint. Max 5%. Does not cause supply inflation.
  *
  * After fees have been applied, the DAO takes a cut based on the configuration of the FolioDAOFeeRegistry including
- *   a chain-specific minimum fee floor. The remaining portion above the floor is distributed to the Folio's fee recipients.
+ *   a minimum fee floor. The remaining portion above the floor is distributed to the Folio's fee recipients.
  *   Note that this means it is possible for the fee recipients to receive nothing despite configuring a nonzero fee.
  */
 contract Folio is

--- a/contracts/folio/FolioDAOFeeRegistry.sol
+++ b/contracts/folio/FolioDAOFeeRegistry.sol
@@ -13,9 +13,9 @@ import { IRoleRegistry } from "@interfaces/IRoleRegistry.sol";
  *         The fee floor is a lower bound on what can be charged to Folio users, in case
  *         the Folio has set its own top-level fees too low.
  *
- *         For example, if the DAO fee is 50%, and the fee floor is 0.15%, then any TVL fee
- *         that is less than 0.30% will result in the DAO receiving 0.15% and the folio beneficiaries receiving
- *         the TVL fee minus 0.15%. At <=0.15% TVL fee, the DAO receives 0.15% and Folio beneficiaries receive 0%
+ *         For example, if the DAO fee is 33.33%, and the fee floor is 0.10%, then any TVL fee
+ *         that is less than 0.30% will result in the DAO receiving 0.10% and the Folio beneficiaries receiving
+ *         the TVL fee minus 0.10%. At <=0.10% TVL fee, the DAO receives 0.10% and Folio beneficiaries receive 0%
  */
 contract FolioDAOFeeRegistry is IFolioDAOFeeRegistry {
     uint256 public constant FEE_DENOMINATOR = 1e18;
@@ -137,26 +137,10 @@ contract FolioDAOFeeRegistry is IFolioDAOFeeRegistry {
         emit TokenFeeFloorSet(fToken, feeFloor, isActive);
     }
 
-    /// Chain-specific maximum fees
+    /// Maximum fees
     /// @return daoFee D18{1} Maximum DAO fee (platform fee)
     /// @return feeFloor D18{1} Maximum fee floor
-    function _getMaxFee() internal view returns (uint256 daoFee, uint256 feeFloor) {
-        // Mainnet: 50%, 15 bps
-        if (block.chainid == 1) {
-            return (0.5e18, 0.0015e18);
-        }
-
-        // Base: 50%, 15 bps
-        if (block.chainid == 8453) {
-            return (0.5e18, 0.0015e18);
-        }
-
-        // BNB Smart Chain: 33.33%, 10 bps
-        if (block.chainid == 56) {
-            return (1e18 / uint256(3), 0.001e18);
-        }
-
-        // default: 50%, 15 bps
-        return (0.5e18, 0.0015e18);
+    function _getMaxFee() internal pure returns (uint256 daoFee, uint256 feeFloor) {
+        return (1e18 / uint256(3), 0.001e18);
     }
 }

--- a/test/Extreme.t.sol
+++ b/test/Extreme.t.sol
@@ -217,11 +217,7 @@ contract ExtremeTest is BaseExtremeTest {
         vm.stopSnapshotGas(redeemGasTag);
 
         // check balances
-        assertEq(
-            folio.balanceOf(user1),
-            mintAmount / 2 - (mintAmount * MAX_FEE_FLOOR) / 1e18,
-            "wrong user1 balance"
-        );
+        assertEq(folio.balanceOf(user1), mintAmount / 2 - (mintAmount * MAX_FEE_FLOOR) / 1e18, "wrong user1 balance");
         for (uint256 j = 0; j < tokens.length; j++) {
             IERC20 _token = IERC20(tokens[j]);
 

--- a/test/Extreme.t.sol
+++ b/test/Extreme.t.sol
@@ -185,7 +185,7 @@ contract ExtremeTest is BaseExtremeTest {
         vm.stopPrank();
 
         // check balances
-        assertEq(folio.balanceOf(user1), mintAmount - (mintAmount * 3) / 2000, "wrong user1 balance");
+        assertEq(folio.balanceOf(user1), mintAmount - (mintAmount * MAX_FEE_FLOOR) / 1e18, "wrong user1 balance");
         for (uint256 j = 0; j < tokens.length; j++) {
             {}
             IERC20 _token = IERC20(tokens[j]);
@@ -217,7 +217,11 @@ contract ExtremeTest is BaseExtremeTest {
         vm.stopSnapshotGas(redeemGasTag);
 
         // check balances
-        assertEq(folio.balanceOf(user1), mintAmount / 2 - (mintAmount * 3) / 2000, "wrong user1 balance");
+        assertEq(
+            folio.balanceOf(user1),
+            mintAmount / 2 - (mintAmount * MAX_FEE_FLOOR) / 1e18,
+            "wrong user1 balance"
+        );
         for (uint256 j = 0; j < tokens.length; j++) {
             IERC20 _token = IERC20(tokens[j]);
 

--- a/test/Folio.t.sol
+++ b/test/Folio.t.sol
@@ -244,7 +244,7 @@ contract FolioTest is BaseTest {
         DAI.approve(address(folio), type(uint256).max);
         MEME.approve(address(folio), type(uint256).max);
         folio.mint(1e22, user1, 0);
-        assertEq(folio.balanceOf(user1), 1e22 - (1e22 * 3) / 2000, "wrong user1 balance");
+        assertEq(folio.balanceOf(user1), 1e22 - (1e22 * MAX_FEE_FLOOR) / 1e18, "wrong user1 balance");
         assertApproxEqAbs(
             USDC.balanceOf(address(folio)),
             startingUSDCBalance + D6_TOKEN_10K,
@@ -275,10 +275,10 @@ contract FolioTest is BaseTest {
         vm.expectRevert(IFolio.Folio__InsufficientSharesOut.selector);
         folio.mint(1e22, user1, 1e22);
         vm.expectRevert(IFolio.Folio__InsufficientSharesOut.selector);
-        folio.mint(1e22, user1, 1e22 - (1e22 * 3) / 2000 + 1);
+        folio.mint(1e22, user1, 1e22 - (1e22 * MAX_FEE_FLOOR) / 1e18 + 1);
 
         // should succeed
-        folio.mint(1e22, user1, 1e22 - (1e22 * 3) / 2000);
+        folio.mint(1e22, user1, 1e22 - (1e22 * MAX_FEE_FLOOR) / 1e18);
     }
 
     function test_mintZero() public {
@@ -301,7 +301,7 @@ contract FolioTest is BaseTest {
         // set mintFee to 5%
         vm.prank(owner);
         folio.setMintFee(MAX_MINT_FEE);
-        // DAO cut is at 50%
+        // DAO cut is at the default platform fee
 
         vm.startPrank(user1);
         USDC.approve(address(folio), type(uint256).max);
@@ -332,7 +332,8 @@ contract FolioTest is BaseTest {
 
         // mint fee should manifest in total supply and both streams of fee shares
         assertEq(folio.totalSupply(), amt * 2, "total supply off"); // genesis supply + new mint
-        uint256 daoPendingFeeShares = (amt * MAX_MINT_FEE) / 1e18 / 2; // DAO receives 50% of the full mint fee
+        uint256 totalFeeShares = (amt * MAX_MINT_FEE + 1e18 - 1) / 1e18;
+        uint256 daoPendingFeeShares = (totalFeeShares * MAX_DAO_FEE + 1e18 - 1) / 1e18;
         assertEq(folio.daoPendingFeeShares(), daoPendingFeeShares, "wrong dao pending fee shares");
         assertEq(
             folio.feeRecipientsPendingFeeShares(),
@@ -350,7 +351,7 @@ contract FolioTest is BaseTest {
         // set mintFee to 5%
         vm.prank(owner);
         folio.setMintFee(MAX_MINT_FEE);
-        daoFeeRegistry.setDefaultFeeNumerator(MAX_DAO_FEE); // DAO fee 50%
+        daoFeeRegistry.setDefaultFeeNumerator(MAX_DAO_FEE);
 
         vm.startPrank(user1);
         USDC.approve(address(folio), type(uint256).max);
@@ -381,8 +382,9 @@ contract FolioTest is BaseTest {
 
         // minting fee should be manifested in total supply and both streams of fee shares
         assertEq(folio.totalSupply(), amt * 2, "total supply off"); // genesis supply + new mint + 5% increase
-        uint256 daoPendingFeeShares = (amt / 20) / 2;
-        assertEq(folio.daoPendingFeeShares(), daoPendingFeeShares, "wrong dao pending fee shares"); // only 15 bps
+        uint256 totalFeeShares = (amt * MAX_MINT_FEE + 1e18 - 1) / 1e18;
+        uint256 daoPendingFeeShares = (totalFeeShares * MAX_DAO_FEE + 1e18 - 1) / 1e18;
+        assertEq(folio.daoPendingFeeShares(), daoPendingFeeShares, "wrong dao pending fee shares");
         assertEq(
             folio.feeRecipientsPendingFeeShares(),
             amt / 20 - daoPendingFeeShares,
@@ -399,7 +401,7 @@ contract FolioTest is BaseTest {
 
         uint256 defaultFeeFloor = daoFeeRegistry.defaultFeeFloor();
 
-        // set mintingFee to feeFloor, 15 bps
+        // set mintingFee to fee floor
         vm.prank(owner);
         folio.setMintFee(defaultFeeFloor);
         // leave daoFeeRegistry fee at 0 (default)
@@ -460,7 +462,7 @@ contract FolioTest is BaseTest {
         DAI.approve(address(folio), type(uint256).max);
         MEME.approve(address(folio), type(uint256).max);
         folio.mint(1e22, user1, 0);
-        assertEq(folio.balanceOf(user1), 1e22 - (1e22 * 3) / 2000, "wrong user1 balance");
+        assertEq(folio.balanceOf(user1), 1e22 - (1e22 * MAX_FEE_FLOOR) / 1e18, "wrong user1 balance");
         uint256 startingUSDCBalanceFolio = USDC.balanceOf(address(folio));
         uint256 startingDAIBalanceFolio = DAI.balanceOf(address(folio));
         uint256 startingMEMEBalanceFolio = MEME.balanceOf(address(folio));
@@ -795,7 +797,7 @@ contract FolioTest is BaseTest {
         uint256 remainingShares = pendingFeeShares - expectedDaoShares;
         assertEq(
             folio.balanceOf(owner),
-            initialOwnerShares + (remainingShares * 0.9e18) / 1e18 + 1,
+            initialOwnerShares + (remainingShares * 0.9e18) / 1e18,
             "wrong owner shares"
         );
         assertEq(folio.balanceOf(feeReceiver), (remainingShares * 0.1e18) / 1e18, "wrong fee receiver shares");
@@ -990,7 +992,7 @@ contract FolioTest is BaseTest {
         uint256 remainingShares = pendingFeeShares - expectedDaoShares;
         assertEq(
             folio.balanceOf(owner),
-            initialOwnerShares + (remainingShares * 0.9e18) / 1e18 + 1,
+            initialOwnerShares + (remainingShares * 0.9e18) / 1e18,
             "wrong owner shares"
         );
         assertEq(folio.balanceOf(feeReceiver), (remainingShares * 0.1e18) / 1e18, "wrong fee receiver shares");
@@ -1395,7 +1397,7 @@ contract FolioTest is BaseTest {
         assertEq(folio.balanceOf(address(dao)), expectedDaoShares, "wrong dao shares, 1st change");
         assertEq(
             folio.balanceOf(owner),
-            initialOwnerShares + (remainingShares * 0.9e18) / 1e18 + 1,
+            initialOwnerShares + (remainingShares * 0.9e18) / 1e18,
             "wrong owner shares, 1st change"
         );
         assertEq(
@@ -3911,7 +3913,7 @@ contract FolioTest is BaseTest {
         DAI.approve(address(folio), type(uint256).max);
         MEME.approve(address(folio), type(uint256).max);
         folio.mint(1e22, user1, 0);
-        assertEq(folio.balanceOf(user1), 1e22 - (1e22 * 3) / 2000, "wrong user1 balance");
+        assertEq(folio.balanceOf(user1), 1e22 - (1e22 * MAX_FEE_FLOOR) / 1e18, "wrong user1 balance");
 
         (address[] memory basket, uint256[] memory amounts) = folio.toAssets(5e21, Math.Rounding.Floor);
 
@@ -4935,7 +4937,7 @@ contract FolioTest is BaseTest {
         vm.prank(owner);
         folio.setMintFee(MAX_MINT_FEE);
 
-        // DAO fee is 50% by default
+        // DAO fee is MAX_DAO_FEE by default
         daoFeeRegistry.setDefaultFeeNumerator(MAX_DAO_FEE);
 
         vm.startPrank(user1);
@@ -4948,7 +4950,6 @@ contract FolioTest is BaseTest {
 
         // totalFeeShares = amt * 5% = amt/20
         uint256 totalFeeShares = (amt * MAX_MINT_FEE + 1e18 - 1) / 1e18;
-        // daoFeeShares = totalFeeShares * 50% = totalFeeShares / 2
         uint256 daoFeeShares = (totalFeeShares * MAX_DAO_FEE + 1e18 - 1) / 1e18;
         // recipientRaw = totalFeeShares - daoFeeShares
         uint256 recipientRaw = totalFeeShares - daoFeeShares;
@@ -4982,7 +4983,6 @@ contract FolioTest is BaseTest {
         vm.prank(owner);
         folio.setMintFee(MAX_MINT_FEE);
 
-        // DAO fee is 50%
         daoFeeRegistry.setDefaultFeeNumerator(MAX_DAO_FEE);
 
         vm.startPrank(user1);
@@ -5095,7 +5095,6 @@ contract FolioTest is BaseTest {
         vm.prank(owner);
         folio.setFolioSelfFee(0.5e18);
 
-        // set DAO fee to 50%
         daoFeeRegistry.setDefaultFeeNumerator(MAX_DAO_FEE);
 
         // fast forward 1 year
@@ -5130,7 +5129,6 @@ contract FolioTest is BaseTest {
         vm.prank(owner);
         folio.setFolioSelfFee(1e18);
 
-        // set DAO fee to 50%
         daoFeeRegistry.setDefaultFeeNumerator(MAX_DAO_FEE);
 
         // fast forward 1 year

--- a/test/Folio.t.sol
+++ b/test/Folio.t.sol
@@ -795,11 +795,7 @@ contract FolioTest is BaseTest {
         assertEq(folio.balanceOf(address(dao)), expectedDaoShares, "wrong dao shares");
 
         uint256 remainingShares = pendingFeeShares - expectedDaoShares;
-        assertEq(
-            folio.balanceOf(owner),
-            initialOwnerShares + (remainingShares * 0.9e18) / 1e18,
-            "wrong owner shares"
-        );
+        assertEq(folio.balanceOf(owner), initialOwnerShares + (remainingShares * 0.9e18) / 1e18, "wrong owner shares");
         assertEq(folio.balanceOf(feeReceiver), (remainingShares * 0.1e18) / 1e18, "wrong fee receiver shares");
     }
 
@@ -990,11 +986,7 @@ contract FolioTest is BaseTest {
         assertEq(folio.balanceOf(address(dao)), expectedDaoShares, "wrong dao shares");
 
         uint256 remainingShares = pendingFeeShares - expectedDaoShares;
-        assertEq(
-            folio.balanceOf(owner),
-            initialOwnerShares + (remainingShares * 0.9e18) / 1e18,
-            "wrong owner shares"
-        );
+        assertEq(folio.balanceOf(owner), initialOwnerShares + (remainingShares * 0.9e18) / 1e18, "wrong owner shares");
         assertEq(folio.balanceOf(feeReceiver), (remainingShares * 0.1e18) / 1e18, "wrong fee receiver shares");
     }
 

--- a/test/FolioDAOFeeRegistry.t.sol
+++ b/test/FolioDAOFeeRegistry.t.sol
@@ -99,7 +99,7 @@ contract FolioDAOFeeRegistryTest is BaseTest {
     function test_setDefaultFeeNumerator() public {
         uint256 numerator;
         (, numerator, , ) = daoFeeRegistry.getFeeDetails(address(folio));
-        assertEq(numerator, 0.5e18);
+        assertEq(numerator, MAX_DAO_FEE);
 
         vm.expectEmit(true, true, false, true);
         emit IFolioDAOFeeRegistry.DefaultFeeNumeratorSet(0.1e18);
@@ -124,7 +124,7 @@ contract FolioDAOFeeRegistryTest is BaseTest {
     function test_setTokenFeeNumerator() public {
         uint256 numerator;
         (, numerator, , ) = daoFeeRegistry.getFeeDetails(address(folio));
-        assertEq(numerator, 0.5e18);
+        assertEq(numerator, MAX_DAO_FEE);
 
         vm.expectEmit(true, true, false, true);
         emit IFolioDAOFeeRegistry.TokenFeeNumeratorSet(address(folio), 0.1e18, true);
@@ -148,7 +148,7 @@ contract FolioDAOFeeRegistryTest is BaseTest {
     function test_usesDefaultFeeNumeratorOnlyWhenTokenNumeratorIsNotSet() public {
         uint256 numerator;
         (, numerator, , ) = daoFeeRegistry.getFeeDetails(address(folio));
-        assertEq(numerator, 0.5e18); // default
+        assertEq(numerator, MAX_DAO_FEE); // default
 
         // set new value for default fee numerator
         daoFeeRegistry.setDefaultFeeNumerator(0.05e18);

--- a/test/base/BaseTest.sol
+++ b/test/base/BaseTest.sol
@@ -34,8 +34,8 @@ abstract contract BaseTest is Script, Test {
     string public constant VERSION = "6.0.0";
     // === Constants per-chain ===
 
-    uint256 internal constant MAX_DAO_FEE = 0.5e18;
-    uint256 internal constant MAX_FEE_FLOOR = 0.0015e18;
+    uint256 internal constant MAX_DAO_FEE = 1e18 / uint256(3);
+    uint256 internal constant MAX_FEE_FLOOR = 0.001e18;
 
     // === Auth roles ===
     bytes32 public constant DEFAULT_ADMIN_ROLE = 0x00;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified fee floor rules in the README, including the default 10 bps annual fee floor and DAO cap limits.
  * Updated contract comments and examples to reflect the new fee floor behavior.

* **Bug Fixes**
  * Standardized fee floor calculations across fee routing and fee distribution expectations.
  * Adjusted rounding behavior so fee-share accounting matches the updated floor and maximum fee values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->