### PR TITLE
6.0.0 touchups

### DIFF
--- a/contracts/Folio.sol
+++ b/contracts/Folio.sol
@@ -480,8 +480,8 @@ contract Folio is
     /// @param assets Assets to receive, must match basket exactly
     /// @param minAmountsOut {tok} Minimum amounts of each asset to receive
     /// @return _amounts {tok} Actual amounts transferred of each asset
-    /// @dev Redeeming to Folio directly skips minAmountOut checks and transfers,
-    ///      mainly useful for donating shares to the Folio.
+    /// @dev Redeeming to Folio directly skips transfers, mainly useful for donating
+    ///      shares to the Folio.
     function redeem(
         uint256 shares,
         address receiver,
@@ -500,14 +500,14 @@ contract Folio is
         uint256 len = _assets.length;
         require(len == assets.length && len == minAmountsOut.length, Folio__InvalidArrayLengths());
 
-        if (receiver != address(this)) {
-            for (uint256 i; i < len; i++) {
-                require(_assets[i] == assets[i], Folio__InvalidAsset());
-                require(_amounts[i] >= minAmountsOut[i], Folio__InvalidAssetAmount(_assets[i]));
+        bool toSelf = receiver == address(this);
 
-                if (_amounts[i] != 0) {
-                    SafeERC20.safeTransfer(IERC20(_assets[i]), receiver, _amounts[i]);
-                }
+        for (uint256 i; i < len; i++) {
+            require(_assets[i] == assets[i], Folio__InvalidAsset());
+            require(_amounts[i] >= minAmountsOut[i], Folio__InvalidAssetAmount(_assets[i]));
+
+            if (!toSelf && _amounts[i] != 0) {
+                SafeERC20.safeTransfer(IERC20(_assets[i]), receiver, _amounts[i]);
             }
         }
     }

--- a/contracts/deployer/FolioDeployer.sol
+++ b/contracts/deployer/FolioDeployer.sol
@@ -140,7 +140,13 @@ contract FolioDeployer is IFolioDeployer, Versioned {
         require(stToken != address(0), FolioDeployer__InvalidStToken());
         IOptimisticVotes(stToken).getPastOptimisticVotes(address(0), block.timestamp - 1);
 
-        bytes32 deploymentSalt = keccak256(abi.encode(msg.sender, deploymentNonce));
+        bytes32 deploymentSalt = keccak256(
+            abi.encode(
+                msg.sender,
+                keccak256(abi.encode(stToken, basicDetails, additionalDetails, folioFlags, govParams, govRoles)),
+                deploymentNonce
+            )
+        );
 
         // Deploy Folio
         (folio, proxyAdmin) = deployFolio(

--- a/test/Folio.t.sol
+++ b/test/Folio.t.sol
@@ -4017,6 +4017,16 @@ contract FolioTest is BaseTest {
         vm.expectRevert(IFolio.Folio__InvalidAsset.selector);
         folio.redeem(5e21, user1, basket, amounts);
 
+        (basket, amounts) = folio.toAssets(5e21, Math.Rounding.Floor);
+        amounts[0] += 1;
+        vm.expectRevert(abi.encodeWithSelector(IFolio.Folio__InvalidAssetAmount.selector, basket[0]));
+        folio.redeem(5e21, address(folio), basket, amounts);
+
+        amounts[0] -= 1; // restore amounts
+        basket[2] = address(USDT); // not in basket
+        vm.expectRevert(IFolio.Folio__InvalidAsset.selector);
+        folio.redeem(5e21, address(folio), basket, amounts);
+
         address[] memory smallerBasket = new address[](0);
         vm.expectRevert(IFolio.Folio__InvalidArrayLengths.selector);
         folio.redeem(5e21, user1, smallerBasket, amounts);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved redemption validation, including redemptions directed to the Folio itself.
  - Invalid asset addresses and insufficient output amounts are now consistently rejected.
  - Redemptions to the Folio skip transfers while still enforcing validation rules.
  - Deployment addresses are now more reliably unique across differing configuration settings.

- **Tests**
  - Added coverage for invalid redemption parameters when redeeming to the Folio address.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->