### PR TITLE
Require trusted filler address for emergency close

### DIFF
--- a/contracts/Folio.sol
+++ b/contracts/Folio.sol
@@ -902,7 +902,12 @@ contract Folio is
     /// Close fill attempting to claw assets back, but always close fill
     /// @dev Callable by ADMIN
     /// @dev Clawed-back token balances will not be reflected in maxAuctionSize tracking
-    function emergencyCloseTrustedFill() external onlyRole(DEFAULT_ADMIN_ROLE) nonReentrant {
+    function emergencyCloseTrustedFill(address trustedFill) external onlyRole(DEFAULT_ADMIN_ROLE) nonReentrant {
+        require(
+            address(activeTrustedFill) != address(0) && address(activeTrustedFill) == trustedFill,
+            Folio__InvalidTrustedFill()
+        );
+
         _closeTrustedFill(true);
     }
 

--- a/contracts/interfaces/IFolio.sol
+++ b/contracts/interfaces/IFolio.sol
@@ -97,6 +97,7 @@ interface IFolio {
     error Folio__InvalidRegistry();
     error Folio__TrustedFillerRegistryNotEnabled();
     error Folio__TrustedFillerRegistryAlreadySet();
+    error Folio__InvalidTrustedFill();
     error Folio__InvalidTTL();
     error Folio__DeadlineExpired();
     error Folio__NotRebalancing();

--- a/test/Folio.t.sol
+++ b/test/Folio.t.sol
@@ -2318,6 +2318,13 @@ contract FolioTest is BaseTest {
         );
         assertEq(address(fill), address(uint160(uint256(vm.load(address(folio), bytes32(uint256(19)))))));
 
+        // should only emergency close the named active fill
+
+        vm.startPrank(owner);
+        vm.expectRevert(IFolio.Folio__InvalidTrustedFill.selector);
+        folio.emergencyCloseTrustedFill(address(1));
+        vm.stopPrank();
+
         // should mint, closing fill
 
         vm.startPrank(user1);
@@ -2349,6 +2356,22 @@ contract FolioTest is BaseTest {
         // should redeem, closing fill
 
         folio.redeem((1e22 * 3) / 20, user1, basket, amounts);
+        vm.stopPrank();
+        assertEq(address(0), address(uint160(uint256(vm.load(address(folio), bytes32(uint256(19)))))));
+
+        // should revert if there is no active fill, even if address(0) is provided
+
+        vm.startPrank(owner);
+        vm.expectRevert(IFolio.Folio__InvalidTrustedFill.selector);
+        folio.emergencyCloseTrustedFill(address(0));
+
+        // should emergency close the named active fill
+
+        fill = folio.createTrustedFill(0, USDC, IERC20(address(USDT)), cowswapFiller, bytes32(block.timestamp + 2));
+        vm.roll(block.number + 1);
+        folio.emergencyCloseTrustedFill(address(fill));
+        vm.stopPrank();
+
         assertEq(address(0), address(uint160(uint256(vm.load(address(folio), bytes32(uint256(19)))))));
     }
 


### PR DESCRIPTION
## Summary
- require `emergencyCloseTrustedFill` callers to provide the active trusted filler address
- revert when a different filler is supplied or no trusted fill is active
- cover incorrect, absent, and correct active filler cases

## Tests
- `forge test --match-test test_trustedFillerNegativeCases`
- `pnpm run test:core`
- `pnpm run lint:check` (passes with existing warnings)
- `pnpm exec prettier --check contracts/Folio.sol contracts/interfaces/IFolio.sol test/Folio.t.sol`