### PR TITLE
Make basket management idempotent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Add per-auction custom auction lengths (`AUCTION_LAUNCHER`, within admin-configured max length)
 - Add explicit rebalance nonce validation
 - Add trusted-fill cleanup and emergency-close improvements
+- Make basket membership changes idempotent, matching allowlist management
 
 ## Release 5.0.0
 

--- a/contracts/Folio.sol
+++ b/contracts/Folio.sol
@@ -289,12 +289,12 @@ contract Folio is
     /// @dev Does not require a token balance
     /// @param token The token to add to the basket
     function addToBasket(IERC20 token) external nonReentrant onlyRole(DEFAULT_ADMIN_ROLE) {
-        require(_addToBasket(address(token)), Folio__BasketModificationFailed());
+        _addToBasket(address(token));
     }
 
     /// @dev Manual admin removal of tokens from the basket
     function removeFromBasket(IERC20 token) external nonReentrant onlyRole(DEFAULT_ADMIN_ROLE) {
-        require(_removeFromBasket(address(token)), Folio__BasketModificationFailed());
+        _removeFromBasket(address(token));
     }
 
     /// An annual TVL fee below the DAO fee floor will result in the entirety of the fee being sent to the DAO
@@ -1132,19 +1132,20 @@ contract Folio is
         }
     }
 
-    function _addToBasket(address token) internal returns (bool) {
+    function _addToBasket(address token) internal {
         require(token != address(0) && token != address(this), Folio__InvalidAsset());
-        emit BasketTokenAdded(token);
 
-        return basket.add(token);
+        if (basket.add(token)) {
+            emit BasketTokenAdded(token);
+        }
     }
 
-    function _removeFromBasket(address token) internal returns (bool) {
-        emit BasketTokenRemoved(token);
+    function _removeFromBasket(address token) internal {
+        if (basket.remove(token)) {
+            delete rebalance.details[token];
 
-        delete rebalance.details[token];
-
-        return basket.remove(token);
+            emit BasketTokenRemoved(token);
+        }
     }
 
     function _setTrustedFillerRegistry(address _newFillerRegistry, bool _enabled) internal {

--- a/contracts/interfaces/IFolio.sol
+++ b/contracts/interfaces/IFolio.sol
@@ -63,7 +63,6 @@ interface IFolio {
     error Folio__Unauthorized();
 
     error Folio__EmptyAssets();
-    error Folio__BasketModificationFailed();
 
     error Folio__FeeRecipientInvalidAddress();
     error Folio__FeeRecipientInvalidFeeShare();

--- a/test/Folio.t.sol
+++ b/test/Folio.t.sol
@@ -552,13 +552,18 @@ contract FolioTest is BaseTest {
         vm.stopPrank();
     }
 
-    function test_cannotAddToBasketIfDuplicate() public {
+    function test_addToBasketIfDuplicateDoesNothing() public {
         (address[] memory _assets, ) = folio.totalAssets();
         assertEq(_assets.length, 3, "wrong assets length");
 
         vm.startPrank(owner);
-        vm.expectRevert(IFolio.Folio__BasketModificationFailed.selector);
-        folio.addToBasket(USDC); // cannot add duplicate
+        vm.recordLogs();
+        folio.addToBasket(USDC);
+        Vm.Log[] memory entries = vm.getRecordedLogs();
+        assertEq(entries.length, 0, "should not emit event for duplicate add");
+
+        (_assets, ) = folio.totalAssets();
+        assertEq(_assets.length, 3, "wrong assets length");
         vm.stopPrank();
     }
 
@@ -618,13 +623,18 @@ contract FolioTest is BaseTest {
         assertEq(_assets[1], address(DAI), "wrong second asset");
     }
 
-    function test_cannotRemoveFromBasketIfNotAvailable() public {
+    function test_removeFromBasketIfNotAvailableDoesNothing() public {
         (address[] memory _assets, ) = folio.totalAssets();
         assertEq(_assets.length, 3, "wrong assets length");
 
         vm.startPrank(owner);
-        vm.expectRevert(IFolio.Folio__BasketModificationFailed.selector);
-        folio.removeFromBasket(USDT); // cannot remove, not in basket
+        vm.recordLogs();
+        folio.removeFromBasket(USDT);
+        Vm.Log[] memory entries = vm.getRecordedLogs();
+        assertEq(entries.length, 0, "should not emit event for unavailable removal");
+
+        (_assets, ) = folio.totalAssets();
+        assertEq(_assets.length, 3, "wrong assets length");
         vm.stopPrank();
     }
 


### PR DESCRIPTION
Stacked on #201.

## Summary

- make `addToBasket()` and `removeFromBasket()` silently continue when membership is already in the requested state
- emit basket events and clear rebalance details only when membership actually changes
- remove the unused `Folio__BasketModificationFailed` error
- document the behavior in the 6.0.0 changelog

## Verification

- `forge test --match-test "test_(addToBasket|removeFromBasket)" -vv`
- `pnpm format:check`
- `pnpm lint:check` (passes with existing warnings)
- `pnpm compile`
- `pnpm test:core` (216 tests)
- `pnpm size`
- `pnpm export`