### PR TITLE
Direct mint self-fees to pre-mint holders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 - Add per-auction custom auction lengths (`AUCTION_LAUNCHER`, within admin-configured max length)
 - Add explicit rebalance nonce validation
 - Add trusted-fill cleanup and emergency-close improvements
+- Price every share allocation created during a mint at the post-self-fee exchange rate when
+  `folioFeeForSelf` is nonzero. This directs the mint self-fee exclusively to pre-mint Folio holders instead of
+  partially refunding the minter. Frontends must account for the pre-mint total supply and self-fee when quoting
+  `sharesOut` and setting `minSharesOut`; `sharesOut` can be lower than `shares - totalFeeShares`.
 
 ## Release 5.0.0
 

--- a/contracts/Folio.sol
+++ b/contracts/Folio.sol
@@ -189,7 +189,7 @@ contract Folio is
     // === 6.0.0 ===
     bool public tradeAllowlistEnabled;
     EnumerableSet.AddressSet private tradeTokenAllowlist;
-    uint256 public folioFeeForSelf; // D18{1} fraction of fee-recipient shares to burn
+    uint256 public folioFeeForSelf; // D18{1} fraction of fee-recipient value directed to Folio holders
 
     FeeRecipient[] public immutableFeeRecipients;
 
@@ -315,9 +315,9 @@ contract Folio is
         _setMintFee(_newFee);
     }
 
-    /// Set the folio fee — fraction of fee-recipient shares that are burned (not minted)
+    /// Set the folio fee — fraction of fee-recipient value directed to Folio holders
     /// @dev Non-reentrant via distributeFees()
-    /// @param _newFee D18{1} Fraction of fee-recipient shares to burn
+    /// @param _newFee D18{1} Fraction of fee-recipient value directed to Folio holders
     function setFolioSelfFee(uint256 _newFee) external onlyRole(DEFAULT_ADMIN_ROLE) {
         distributeFees();
 
@@ -435,8 +435,10 @@ contract Folio is
 
     /// @dev Use allowances to set slippage limits for provided assets
     /// @dev Minting has 3 share-portions: (i) receiver shares, (ii) DAO fee shares, (iii) fee recipients shares
+    /// @dev When folioFeeForSelf is nonzero, all 3 portions are priced at the post-self-fee exchange rate so the
+    ///      self-fee benefits only shares that existed before the mint
     /// @param shares {share} Amount of shares to mint
-    /// @param minSharesOut {share} Minimum amount of shares the caller must receive after fees
+    /// @param minSharesOut {share} Minimum amount of post-self-fee shares the caller must receive
     /// @return _assets
     /// @return _amounts {tok}
     function mint(
@@ -1076,7 +1078,7 @@ contract Folio is
         emit MintFeeSet(_newFee);
     }
 
-    /// Set folio fee — fraction of fee-recipient shares to burn
+    /// Set folio fee — fraction of fee-recipient value directed to Folio holders
     /// @param _newFee D18{1}
     function _setFolioSelfFee(uint256 _newFee) internal {
         require(_newFee <= MAX_FOLIO_FEE, Folio__FolioFeeTooHigh());

--- a/contracts/interfaces/IFolio.sol
+++ b/contracts/interfaces/IFolio.sol
@@ -130,7 +130,7 @@ interface IFolio {
         FeeRecipient[] immutableFeeRecipients;
         uint256 tvlFee; // D18{1/year} annual fee input; stored on Folio as D18{1/s}
         uint256 mintFee; // D18{1}
-        uint256 folioFeeForSelf; // D18{1} fraction of fee-recipient shares to burn
+        uint256 folioFeeForSelf; // D18{1} fraction of fee-recipient value directed to Folio holders
         string mandate;
     }
 

--- a/contracts/utils/FolioLib.sol
+++ b/contracts/utils/FolioLib.sol
@@ -1,6 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.28;
 
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { Math } from "@openzeppelin/contracts/utils/math/Math.sol";
+
 import { IFolio } from "@interfaces/IFolio.sol";
 import { IFolioDAOFeeRegistry } from "@interfaces/IFolioDAOFeeRegistry.sol";
 
@@ -139,7 +142,7 @@ library FolioLib {
         uint256 currentDaoPending; // {share}
         uint256 currentFeeRecipientsPending; // {share}
         uint256 tvlFee; // D18{1/s}
-        uint256 folioFeeForSelf; // D18{1} fraction of fee-recipient shares to burn
+        uint256 folioFeeForSelf; // D18{1} fraction of fee-recipient value directed to Folio holders
         uint256 supply; // {share}
         uint256 elapsed; // {s}
     }
@@ -212,9 +215,9 @@ library FolioLib {
     /// Compute mint fee shares for DAO and fee recipients
     /// @param params Mint fee parameters
     /// @param daoFeeRegistry The DAO fee registry to query fee details from
-    /// @return sharesOut {share} Shares to mint for the receiver
-    /// @return daoFeeShares {share} Shares owed to the DAO
-    /// @return feeRecipientFeeShares {share} Shares owed to fee recipients (excludes self-fee shares)
+    /// @return sharesOut {share} Shares to mint for the receiver at the post-self-fee exchange rate
+    /// @return daoFeeShares {share} Shares owed to the DAO at the post-self-fee exchange rate
+    /// @return feeRecipientFeeShares {share} Shares owed to fee recipients at the post-self-fee exchange rate
     function computeMintFees(
         MintFeeParams calldata params,
         IFolioDAOFeeRegistry daoFeeRegistry
@@ -237,13 +240,36 @@ library FolioLib {
         // 100% to DAO, if necessary
         totalFeeShares = totalFeeShares < daoFeeShares ? daoFeeShares : totalFeeShares;
 
-        // apply folioFeeForSelf to recipient portion
+        // direct folioFeeForSelf to holders in the pre-mint supply
         feeRecipientFeeShares = totalFeeShares - daoFeeShares;
         uint256 folioSelfShares = (feeRecipientFeeShares * params.folioFeeForSelf) / D18;
         feeRecipientFeeShares -= folioSelfShares;
 
-        // {share} minter pays the full fee (including self-fee shares that are burned)
+        // {share} = {share} - {share}
         sharesOut = params.shares - totalFeeShares;
+
+        if (folioSelfShares != 0) {
+            // Price every new share allocation at the post-self-fee exchange rate so only pre-mint holders
+            // receive the self-fee. Cap total issuance by rounding down, then round aggregate fee shares up.
+            uint256 supply = IERC20(address(this)).totalSupply();
+            uint256 scaleDenominator = supply + folioSelfShares;
+
+            // {share} = {share} * {share} / {share}
+            uint256 scaledTotalNewShares = Math.mulDiv(params.shares - folioSelfShares, supply, scaleDenominator);
+
+            // {share} = {share} * {share} / {share}
+            uint256 scaledTotalFeeShares = Math.mulDiv(
+                daoFeeShares + feeRecipientFeeShares,
+                supply,
+                scaleDenominator,
+                Math.Rounding.Ceil
+            );
+
+            sharesOut = scaledTotalNewShares > scaledTotalFeeShares ? scaledTotalNewShares - scaledTotalFeeShares : 0;
+            daoFeeShares = Math.mulDiv(daoFeeShares, supply, scaleDenominator, Math.Rounding.Ceil);
+            feeRecipientFeeShares = scaledTotalFeeShares - daoFeeShares;
+        }
+
         require(sharesOut != 0 && sharesOut >= params.minSharesOut, IFolio.Folio__InsufficientSharesOut());
 
         emit IFolio.FolioFeePaid(address(this), folioSelfShares);

--- a/test/Folio.t.sol
+++ b/test/Folio.t.sol
@@ -5015,6 +5015,25 @@ contract FolioTest is BaseTest {
     //   folioFeeForSelf tests
     // =========================================================
 
+    function _assertAssetValue(
+        uint256 shares,
+        uint256[] memory assetsBefore,
+        uint256 valueShares,
+        uint256 supplyBefore,
+        string memory err
+    ) internal view {
+        (, uint256[] memory assetsAfter) = folio.toAssets(shares, Math.Rounding.Floor);
+
+        for (uint256 i; i < assetsBefore.length; i++) {
+            uint256 tolerance = 1;
+            if (i == 1) tolerance = 2;
+            if (i == 2) tolerance = 2e9;
+
+            uint256 expectedAssets = Math.mulDiv(assetsBefore[i], valueShares, supplyBefore);
+            assertApproxEqAbs(assetsAfter[i], expectedAssets, tolerance, err);
+        }
+    }
+
     function test_setFolioFee() public {
         vm.startPrank(owner);
 
@@ -5084,7 +5103,7 @@ contract FolioTest is BaseTest {
         assertTrue(folio.balanceOf(dao) > initialDaoShares, "dao should have received fees");
     }
 
-    /// @dev With folioFeeForSelf at 50%, half of the fee-recipient shares on mint should be burned
+    /// @dev With folioFeeForSelf at 50%, half of the fee-recipient value benefits pre-mint holders
     function test_mintWithFolioFeeForSelf() public {
         // set folioFeeForSelf to 50%
         vm.prank(owner);
@@ -5103,6 +5122,7 @@ contract FolioTest is BaseTest {
         MEME.approve(address(folio), type(uint256).max);
 
         uint256 amt = 1e22;
+        uint256 supplyBefore = folio.totalSupply();
         folio.mint(amt, user1, 0);
 
         // totalFeeShares = amt * 5% = amt/20
@@ -5110,19 +5130,31 @@ contract FolioTest is BaseTest {
         uint256 daoFeeShares = (totalFeeShares * MAX_DAO_FEE + 1e18 - 1) / 1e18;
         // recipientRaw = totalFeeShares - daoFeeShares
         uint256 recipientRaw = totalFeeShares - daoFeeShares;
-        // selfShares (burned) = recipientRaw * 50%
+        // selfShares (directed to pre-mint holders) = recipientRaw * 50%
         uint256 selfShares = (recipientRaw * 0.5e18) / 1e18;
-        uint256 expectedFeeRecipientShares = recipientRaw - selfShares;
+        uint256 recipientAfterSelf = recipientRaw - selfShares;
+        uint256 scaleDenominator = supplyBefore + selfShares;
 
-        // user pays full fee (incl self-fee shares that are not minted)
-        uint256 expectedSharesOut = amt - totalFeeShares;
+        // All shares created by the mint are priced at the post-self-fee exchange rate.
+        uint256 expectedTotalNewShares = Math.mulDiv(amt - selfShares, supplyBefore, scaleDenominator);
+        uint256 expectedTotalFeeShares = Math.mulDiv(
+            daoFeeShares + recipientAfterSelf,
+            supplyBefore,
+            scaleDenominator,
+            Math.Rounding.Ceil
+        );
+        uint256 expectedDaoFeeShares = Math.mulDiv(daoFeeShares, supplyBefore, scaleDenominator, Math.Rounding.Ceil);
+        uint256 expectedFeeRecipientShares = expectedTotalFeeShares - expectedDaoFeeShares;
+        uint256 expectedSharesOut = expectedTotalNewShares - expectedTotalFeeShares;
         assertEq(folio.balanceOf(user1), expectedSharesOut, "wrong user shares out");
 
-        // total supply: genesis + sharesOut + daoFee + feeRecipientFee (self-fee NOT minted)
-        uint256 expectedTotalSupply = INITIAL_SUPPLY + expectedSharesOut + daoFeeShares + expectedFeeRecipientShares;
+        uint256 expectedTotalSupply = supplyBefore +
+            expectedSharesOut +
+            expectedDaoFeeShares +
+            expectedFeeRecipientShares;
         assertEq(folio.totalSupply(), expectedTotalSupply, "wrong total supply with folioFeeForSelf");
 
-        assertEq(folio.daoPendingFeeShares(), daoFeeShares, "wrong dao pending fee shares");
+        assertEq(folio.daoPendingFeeShares(), expectedDaoFeeShares, "wrong dao pending fee shares");
         assertEq(
             folio.feeRecipientsPendingFeeShares(),
             expectedFeeRecipientShares,
@@ -5130,7 +5162,60 @@ contract FolioTest is BaseTest {
         );
     }
 
-    /// @dev With folioFeeForSelf at 100%, ALL fee-recipient shares on mint are burned
+    /// @dev Mint self-fees increase the exchange rate for pre-mint shares without rebating the minter
+    function test_mintWithFolioFeeForSelfBenefitsOnlyPreMintShares() public {
+        vm.prank(owner);
+        folio.setFolioSelfFee(0.5e18);
+
+        vm.prank(owner);
+        folio.setMintFee(MAX_MINT_FEE);
+
+        daoFeeRegistry.setDefaultFeeNumerator(MAX_DAO_FEE);
+
+        vm.startPrank(user1);
+        USDC.approve(address(folio), type(uint256).max);
+        DAI.approve(address(folio), type(uint256).max);
+        MEME.approve(address(folio), type(uint256).max);
+
+        uint256 amt = 1e22;
+        uint256 supplyBefore = folio.totalSupply();
+        (, uint256[] memory assetsBefore) = folio.totalAssets();
+
+        uint256 totalFeeShares = Math.mulDiv(amt, MAX_MINT_FEE, 1e18, Math.Rounding.Ceil);
+        uint256 daoFeeShares = Math.mulDiv(totalFeeShares, MAX_DAO_FEE, 1e18, Math.Rounding.Ceil);
+        uint256 selfShares = Math.mulDiv(totalFeeShares - daoFeeShares, 0.5e18, 1e18);
+
+        folio.mint(amt, user1, 0);
+
+        uint256 rawUserShares = amt - totalFeeShares;
+        uint256 rawFeeRecipientShares = totalFeeShares - daoFeeShares - selfShares;
+
+        _assertAssetValue(
+            folio.balanceOf(owner),
+            assetsBefore,
+            supplyBefore + selfShares,
+            supplyBefore,
+            "wrong pre-mint holder assets"
+        );
+        _assertAssetValue(
+            folio.balanceOf(user1),
+            assetsBefore,
+            rawUserShares,
+            supplyBefore,
+            "minter received self-fee refund"
+        );
+        _assertAssetValue(folio.daoPendingFeeShares(), assetsBefore, daoFeeShares, supplyBefore, "wrong dao fee value");
+        _assertAssetValue(
+            folio.feeRecipientsPendingFeeShares(),
+            assetsBefore,
+            rawFeeRecipientShares,
+            supplyBefore,
+            "wrong fee recipient value"
+        );
+        vm.stopPrank();
+    }
+
+    /// @dev With folioFeeForSelf at 100%, ALL fee-recipient value on mint benefits pre-mint holders
     function test_mintWithFolioFeeForSelf_100Percent() public {
         // set folioFeeForSelf to 100%
         vm.prank(owner);
@@ -5148,21 +5233,26 @@ contract FolioTest is BaseTest {
         MEME.approve(address(folio), type(uint256).max);
 
         uint256 amt = 1e22;
+        uint256 supplyBefore = folio.totalSupply();
         folio.mint(amt, user1, 0);
 
         // totalFeeShares = amt * 5%
         uint256 totalFeeShares = (amt * MAX_MINT_FEE + 1e18 - 1) / 1e18;
         uint256 daoFeeShares = (totalFeeShares * MAX_DAO_FEE + 1e18 - 1) / 1e18;
 
-        // ALL fee-recipient shares are burned (folioFeeForSelf = 100%)
-        assertEq(folio.feeRecipientsPendingFeeShares(), 0, "fee recipients should get 0 with 100% folioFee");
-        assertEq(folio.daoPendingFeeShares(), daoFeeShares, "wrong dao pending fee shares");
+        uint256 recipientRaw = totalFeeShares - daoFeeShares;
+        uint256 scaleDenominator = supplyBefore + recipientRaw;
+        uint256 expectedTotalNewShares = Math.mulDiv(amt - recipientRaw, supplyBefore, scaleDenominator);
+        uint256 expectedDaoFeeShares = Math.mulDiv(daoFeeShares, supplyBefore, scaleDenominator, Math.Rounding.Ceil);
+        uint256 expectedSharesOut = expectedTotalNewShares - expectedDaoFeeShares;
 
-        uint256 expectedSharesOut = amt - totalFeeShares;
+        // ALL fee-recipient value goes to pre-mint holders (folioFeeForSelf = 100%)
+        assertEq(folio.feeRecipientsPendingFeeShares(), 0, "fee recipients should get 0 with 100% folioFee");
+        assertEq(folio.daoPendingFeeShares(), expectedDaoFeeShares, "wrong dao pending fee shares");
+
         assertEq(folio.balanceOf(user1), expectedSharesOut, "wrong user shares out");
 
-        // total supply = genesis + sharesOut + daoFee (no fee-recipient shares minted)
-        uint256 expectedTotalSupply = INITIAL_SUPPLY + expectedSharesOut + daoFeeShares;
+        uint256 expectedTotalSupply = supplyBefore + expectedSharesOut + expectedDaoFeeShares;
         assertEq(folio.totalSupply(), expectedTotalSupply, "wrong total supply");
     }
 
@@ -5394,11 +5484,23 @@ contract FolioTest is BaseTest {
         MEME.approve(address(folio), type(uint256).max);
 
         uint256 amt = 1e22;
+        uint256 supplyBefore = folio.totalSupply();
         // totalFeeShares = amt * 5%
         uint256 totalFeeShares = (amt * MAX_MINT_FEE + 1e18 - 1) / 1e18;
-        uint256 expectedSharesOut = amt - totalFeeShares;
+        uint256 daoFeeShares = (totalFeeShares * MAX_DAO_FEE + 1e18 - 1) / 1e18;
+        uint256 recipientRaw = totalFeeShares - daoFeeShares;
+        uint256 selfShares = (recipientRaw * 0.5e18) / 1e18;
+        uint256 scaleDenominator = supplyBefore + selfShares;
+        uint256 expectedTotalNewShares = Math.mulDiv(amt - selfShares, supplyBefore, scaleDenominator);
+        uint256 expectedTotalFeeShares = Math.mulDiv(
+            totalFeeShares - selfShares,
+            supplyBefore,
+            scaleDenominator,
+            Math.Rounding.Ceil
+        );
+        uint256 expectedSharesOut = expectedTotalNewShares - expectedTotalFeeShares;
 
-        // should revert if minSharesOut is too high (user pays full fee including self-fee)
+        // should revert if minSharesOut does not account for the post-self-fee exchange rate
         vm.expectRevert(IFolio.Folio__InsufficientSharesOut.selector);
         folio.mint(amt, user1, expectedSharesOut + 1);
 


### PR DESCRIPTION
## Summary

- price receiver, DAO, and fee-recipient allocations at the post-self-fee exchange rate
- direct mint self-fee appreciation exclusively to shares that existed before the mint
- document the frontend-visible sharesOut and minSharesOut quoting change in the changelog
- add allocation and economic-value tests across 6, 18, and 27 decimal basket assets

## Accounting

Gross basket assets deposited remain unchanged. When folioFeeForSelf is nonzero, total new issuance is scaled by preMintSupply / (preMintSupply + selfFeeShares). Total issuance rounds down, while aggregate non-self fee shares and DAO shares round up, preserving the DAO fee floor and assigning rounding dust to existing holders.

## Frontend impact

sharesOut can be lower than shares minus totalFeeShares. Quotes and minSharesOut must account for the current pre-mint total supply and the self-fee portion.

## Verification

- pnpm format:check
- pnpm test:core
- pnpm test:extreme
- pnpm size