### PR TITLE
Document mint self-fee refund behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 - Add optimistic governance
 - Add token allowlist controls for rebalancing (`DEFAULT_ADMIN_ROLE`)
-- Add Folio self-fee (`DEFAULT_ADMIN_ROLE`)
+- Add Folio self-fee (`DEFAULT_ADMIN_ROLE`). On mint, the receiver participates in the resulting exchange-rate
+  appreciation and recovers a size-dependent portion of the self-fee; see `folioFeeForSelf` in the README.
 - Add Folio immutable fee recipients (`DEFAULT_ADMIN_ROLE`)
 - Add per-auction custom auction lengths (`AUCTION_LAUNCHER`, within admin-configured max length)
 - Add explicit rebalance nonce validation

--- a/README.md
+++ b/README.md
@@ -184,6 +184,16 @@ The DAO takes a cut with a minimum floor of 10 bps. The DAO always receives at l
 
 Max: 5%
 
+##### `folioFeeForSelf`
+
+**Fraction of non-DAO fee value directed to Folio holders**
+
+`folioFeeForSelf` applies to the fee-recipient portion of both TVL fees and mint fees. Instead of minting the configured fraction of fee-recipient shares, the Folio omits those shares from its supply. The underlying assets remain in the Folio, increasing the assets represented by each outstanding share.
+
+For mint fees, the receiver still receives `shares - totalFeeShares`, including a deduction for the omitted self-fee shares. However, those newly minted receiver shares immediately participate in the resulting exchange-rate increase. The receiver therefore recovers a portion of the self-fee value equal to its newly minted fraction of the post-mint supply, subject to rounding. The effect is small for mints that are small relative to the existing supply and increases with the relative size of the mint. The DAO fee portion, including the minimum DAO fee floor, is minted separately and is not recovered through this effect.
+
+Breaking a large mint into smaller sequential mints results in a smaller overall rebate, apart from rounding and fee-floor edge effects, because later tranches do not participate in the appreciation caused by earlier mints. Separately, an account that becomes a holder immediately before another account's mint and redeems afterward can capture a portion of that mint's self-fee.
+
 #### Fee Floor
 
 The default 10 bps fee floor is capped by the DAO. Per-Folio fee floors can also be set, but they cannot exceed the default floor.


### PR DESCRIPTION
Stacked on top of the #197 chain, after #200.

## Summary

- document how folioFeeForSelf omits non-DAO fee shares and increases the fToken exchange rate
- explain that newly minted receiver shares participate in that appreciation and recover a size-dependent portion of the mint self-fee
- clarify that the DAO portion is not recovered by the receiver
- document the just-in-time holder consequence
- add the frontend-relevant behavior to the 6.0.0 changelog

## Verification

- pnpm exec prettier --check README.md CHANGELOG.md
- git diff --check

Documentation only; no contract behavior changes.