### PR TITLE
Restrict rebalances to allowlisted tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## Release 6.0.0
 
 - Add optimistic governance
-- Add token allowlist controls for rebalancing (`DEFAULT_ADMIN_ROLE`)
+- Add token allowlist controls that restrict every token included in a new rebalance (`DEFAULT_ADMIN_ROLE`)
 - Add Folio self-fee (`DEFAULT_ADMIN_ROLE`). On mint, the receiver participates in the resulting exchange-rate
   appreciation and recovers a size-dependent portion of the self-fee; see `folioFeeForSelf` in the README.
 - Add Folio immutable fee recipients (`DEFAULT_ADMIN_ROLE`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 ## Release 6.0.0
 
 - Add optimistic governance
-- Add token allowlist controls that restrict every token included in a new rebalance (`DEFAULT_ADMIN_ROLE`)
+- Add optional token trading allowlist controls (`DEFAULT_ADMIN_ROLE`). Enforcement is disabled by default; when
+  enabled, every token included in a new rebalance, including zero-weight tokens, must be allowlisted.
 - Add Folio self-fee (`DEFAULT_ADMIN_ROLE`). On mint, the receiver participates in the resulting exchange-rate
   appreciation and recovers a size-dependent portion of the self-fee; see `folioFeeForSelf` in the README.
 - Add Folio immutable fee recipients (`DEFAULT_ADMIN_ROLE`)

--- a/README.md
+++ b/README.md
@@ -277,7 +277,7 @@ The chain is assumed to have block times equal to or under 30s.
 - 3.0.0 (skipped; never deployed): Pairwise auctions around a rebalance
 - 4.0.0: Basket auctions around a rebalance
 - [5.0.0](https://github.com/reserve-protocol/reserve-index-dtf/releases/tag/r5.0.0): Max auction sizes, restricted permissionless bids, and brand/name controls
-- 6.0.0: Optimistic governance, token allowlist controls, Folio self-fee, immutable fee recipients, custom auction lengths, and rebalance nonce validation
+- 6.0.0: Optimistic governance, token trading allowlist controls, Folio self-fee, immutable fee recipients, custom auction lengths, and rebalance nonce validation
 
 ### Future Work / Not Implemented Yet
 

--- a/README.md
+++ b/README.md
@@ -277,7 +277,8 @@ The chain is assumed to have block times equal to or under 30s.
 - 3.0.0 (skipped; never deployed): Pairwise auctions around a rebalance
 - 4.0.0: Basket auctions around a rebalance
 - [5.0.0](https://github.com/reserve-protocol/reserve-index-dtf/releases/tag/r5.0.0): Max auction sizes, restricted permissionless bids, and brand/name controls
-- 6.0.0: Optimistic governance, token trading allowlist controls, Folio self-fee, immutable fee recipients, custom auction lengths, and rebalance nonce validation
+- 6.0.0: Optimistic governance, optional disabled-by-default token trading allowlist controls that gate every token in
+  a new rebalance, Folio self-fee, immutable fee recipients, custom auction lengths, and rebalance nonce validation
 
 ### Future Work / Not Implemented Yet
 

--- a/contracts/Folio.sol
+++ b/contracts/Folio.sol
@@ -388,7 +388,9 @@ contract Folio is
     }
 
     /// Remove tokens from the set approved for trading in new rebalances
-    /// @dev Does not impact ongoing rebalances. Consider calling endRebalance()
+    /// @dev Does not impact ongoing rebalances or auctions
+    /// @dev SHOULD call endRebalance() after removing a token that SHOULD NOT be traded
+    /// @dev Any ongoing auction remains active and must be closed separately
     /// @param tokens The tokens to remove from the allowlist
     function removeFromAllowlist(address[] calldata tokens) external onlyRole(DEFAULT_ADMIN_ROLE) {
         uint256 len = tokens.length;
@@ -687,6 +689,7 @@ contract Folio is
     }
 
     /// Open an auction as the AUCTION_LAUNCHER aimed at specific BU limits and weights, for a given set of tokens
+    /// @dev Does not recheck current token allowlist membership; allowlist enforcement occurs only in startRebalance()
     /// @param rebalanceNonce The nonce of the rebalance being targeted
     /// @param tokens The tokens from the rebalance to include in the auction; must be unique
     /// @param newWeights D27{tok/BU} New basket weight ranges for BU definition; must always be provided
@@ -730,6 +733,7 @@ contract Folio is
 
     /// Open an auction without caller restrictions, on all tokens in the rebalance on spot values and initial prices
     /// @dev Callable only after the restricted window passes, after the 120 second start buffer, and when no other auction is ongoing
+    /// @dev Does not recheck current token allowlist membership; allowlist enforcement occurs only in startRebalance()
     /// @return auctionId The newly created auctionId
     function openAuctionUnrestricted(
         uint256 rebalanceNonce
@@ -808,6 +812,7 @@ contract Folio is
     ///   If withCallback is true, caller must adhere to IBidderCallee interface and receives a callback
     ///   If withCallback is false, caller must have provided an allowance in advance
     /// @dev Callable by anyone
+    /// @dev Does not recheck current token allowlist membership; allowlist enforcement occurs only in startRebalance()
     /// @param sellAmount {sellTok} Sell token, the token the bidder receives
     /// @param maxBuyAmount {buyTok} Max buy token, the token the bidder provides
     /// @param withCallback If true, caller must adhere to IBidderCallee interface and transfers tokens via callback
@@ -835,6 +840,7 @@ contract Folio is
     }
 
     /// As an alternative to bidding directly, an in-block async swap can be opened without removing Folio's access
+    /// @dev Does not recheck current token allowlist membership; allowlist enforcement occurs only in startRebalance()
     function createTrustedFill(
         uint256 auctionId,
         IERC20 sellToken,

--- a/contracts/Folio.sol
+++ b/contracts/Folio.sol
@@ -30,7 +30,8 @@ import { IFolio } from "@interfaces/IFolio.sol";
  *   All tokens tracked by the Folio are required to mint/redeem. This forms the basket.
  *
  * There are 3 main operational roles:
- *   1. DEFAULT_ADMIN_ROLE: can set ERC20 assets, fees, max auction length, close auctions/rebalances, and deprecateFolio
+ *   1. DEFAULT_ADMIN_ROLE: can set ERC20 assets, fees, token trading allowlist, max auction length, close
+ *      auctions/rebalances, and deprecateFolio
  *   2. REBALANCE_MANAGER: can start/end rebalances, and end individual auctions
  *   3. AUCTION_LAUNCHER: can open auctions and end rebalances/auctions
  *
@@ -271,13 +272,13 @@ contract Folio is
 
     // ==== Allowlist ====
 
-    /// @return The list of tokens currently on the allowlist
+    /// @return The list of tokens currently approved for trading in new rebalances
     function getTokenAllowlist() external view returns (address[] memory) {
         return tradeTokenAllowlist.values();
     }
 
     /// @param token The token to check
-    /// @return True if the token is on the allowlist
+    /// @return True if the token is approved for trading in new rebalances
     function isTokenAllowlisted(address token) external view returns (bool) {
         return tradeTokenAllowlist.contains(token);
     }
@@ -370,12 +371,12 @@ contract Folio is
         _setBidsEnabled(_bidsEnabled);
     }
 
-    /// @param _enabled If true, token allowlist is enforced during rebalancing
+    /// @param _enabled If true, only allowlisted tokens can be included in new rebalances
     function setTradeAllowlistEnabled(bool _enabled) external onlyRole(DEFAULT_ADMIN_ROLE) {
         _setTradeAllowlistEnabled(_enabled);
     }
 
-    /// Add tokens to the allowlist
+    /// Add tokens that are safe to trade in new rebalances to the allowlist
     /// @param tokens The tokens to add to the allowlist
     function addToAllowlist(address[] calldata tokens) external onlyRole(DEFAULT_ADMIN_ROLE) {
         uint256 len = tokens.length;
@@ -386,7 +387,7 @@ contract Folio is
         }
     }
 
-    /// Remove tokens from the allowlist
+    /// Remove tokens from the set approved for trading in new rebalances
     /// @dev Does not impact ongoing rebalances. Consider calling endRebalance()
     /// @param tokens The tokens to remove from the allowlist
     function removeFromAllowlist(address[] calldata tokens) external onlyRole(DEFAULT_ADMIN_ROLE) {
@@ -641,7 +642,7 @@ contract Folio is
     /// @dev Note that weights will be _slightly_ stale after the fee supply inflation on a 24h boundary
     /// @param rebalanceNonce The expected nonce after this rebalance starts
     /// @param tokens The rebalance parameters for each token in the rebalance
-    /// @param tokens.token MUST be unique
+    /// @param tokens.token MUST be unique; MUST be allowlisted when the trade allowlist is enabled
     /// @param tokens.weight D27{tok/BU} Basket weight ranges; low <= spot <= high <= 1e54
     /// @param tokens.price D27{UoA/tok} Initial price ranges for each token; low < high <= 1e45
     /// @param tokens.maxAuctionSize {tok} Max amount to sell in any single auction
@@ -658,16 +659,9 @@ contract Folio is
         uint256 ttl,
         uint256 deadline
     ) external onlyRole(REBALANCE_MANAGER) nonReentrant notDeprecated sync {
-        // enforce token allowlist: non-allowlisted tokens can only be traded out (zero weights)
         if (tradeAllowlistEnabled) {
             for (uint256 i; i < tokens.length; i++) {
-                TokenRebalanceParams calldata params = tokens[i];
-                if (!tradeTokenAllowlist.contains(params.token)) {
-                    require(
-                        params.weight.low == 0 && params.weight.spot == 0 && params.weight.high == 0,
-                        Folio__TokenNotAllowlisted()
-                    );
-                }
+                require(tradeTokenAllowlist.contains(tokens[i].token), Folio__TokenNotAllowlisted());
             }
         }
 

--- a/contracts/Folio.sol
+++ b/contracts/Folio.sol
@@ -272,13 +272,13 @@ contract Folio is
 
     // ==== Allowlist ====
 
-    /// @return The list of tokens currently approved for trading in new rebalances
+    /// @return The list of tokens currently on the allowlist
     function getTokenAllowlist() external view returns (address[] memory) {
         return tradeTokenAllowlist.values();
     }
 
     /// @param token The token to check
-    /// @return True if the token is approved for trading in new rebalances
+    /// @return True if the token is on the allowlist
     function isTokenAllowlisted(address token) external view returns (bool) {
         return tradeTokenAllowlist.contains(token);
     }
@@ -387,10 +387,8 @@ contract Folio is
         }
     }
 
-    /// Remove tokens from the set approved for trading in new rebalances
-    /// @dev Does not impact ongoing rebalances or auctions
-    /// @dev SHOULD call endRebalance() after removing a token that SHOULD NOT be traded
-    /// @dev Any ongoing auction remains active and must be closed separately
+    /// Remove tokens from the allowlist
+    /// @dev Does not impact ongoing rebalances. Consider calling endRebalance()
     /// @param tokens The tokens to remove from the allowlist
     function removeFromAllowlist(address[] calldata tokens) external onlyRole(DEFAULT_ADMIN_ROLE) {
         uint256 len = tokens.length;

--- a/test/Allowlist.t.sol
+++ b/test/Allowlist.t.sol
@@ -294,7 +294,7 @@ contract AllowlistTest is BaseTest {
         assertEq(nonce, 1, "rebalance should have started");
     }
 
-    function test_rebalance_allowlistEnabled_rejectsNonAllowlistedTokenWithNonZeroWeights() public {
+    function test_rebalance_allowlistEnabled_rejectsNonAllowlistedToken() public {
         // Only allowlist USDC and DAI, not MEME
         address[] memory tokensToAdd = new address[](2);
         tokensToAdd[0] = address(USDC);
@@ -305,11 +305,11 @@ contract AllowlistTest is BaseTest {
         folio.setTradeAllowlistEnabled(true);
         vm.stopPrank();
 
-        // Try to rebalance with MEME having non-zero weights -- should revert
+        // Try to rebalance with MEME, which is not approved for trading
         IFolio.TokenRebalanceParams[] memory tokens = new IFolio.TokenRebalanceParams[](3);
         tokens[0] = IFolio.TokenRebalanceParams(assets[0], weights[0], prices[0], type(uint256).max, true);
         tokens[1] = IFolio.TokenRebalanceParams(assets[1], weights[1], prices[1], type(uint256).max, true);
-        tokens[2] = IFolio.TokenRebalanceParams(assets[2], weights[2], prices[2], type(uint256).max, true); // MEME with non-zero weights
+        tokens[2] = IFolio.TokenRebalanceParams(assets[2], weights[2], prices[2], type(uint256).max, true);
 
         uint256 rebalanceNonceForExpectedRevert19 = nextRebalanceNonce(folio);
         vm.prank(dao);
@@ -324,7 +324,7 @@ contract AllowlistTest is BaseTest {
         );
     }
 
-    function test_rebalance_allowlistEnabled_nonAllowlistedTokenCanBeTradedOutWithZeroWeights() public {
+    function test_rebalance_allowlistEnabled_rejectsNonAllowlistedTokenWithZeroWeights() public {
         // Only allowlist USDC and DAI, not MEME
         address[] memory tokensToAdd = new address[](2);
         tokensToAdd[0] = address(USDC);
@@ -335,37 +335,11 @@ contract AllowlistTest is BaseTest {
         folio.setTradeAllowlistEnabled(true);
         vm.stopPrank();
 
-        // MEME with SELL (zero) weights -- should succeed (trading out)
+        // Zero target weights do not permit trading a non-allowlisted token out
         IFolio.TokenRebalanceParams[] memory tokens = new IFolio.TokenRebalanceParams[](3);
         tokens[0] = IFolio.TokenRebalanceParams(assets[0], weights[0], prices[0], type(uint256).max, true);
         tokens[1] = IFolio.TokenRebalanceParams(assets[1], weights[1], prices[1], type(uint256).max, true);
-        tokens[2] = IFolio.TokenRebalanceParams(assets[2], SELL, prices[2], type(uint256).max, true); // MEME with zero weights
-
-        vm.prank(dao);
-        startRebalance(folio, tokens, limits, AUCTION_LAUNCHER_WINDOW, MAX_TTL);
-
-        (uint256 nonce, , , , , ) = folio.getRebalance();
-        assertEq(nonce, 1, "rebalance should have started");
-    }
-
-    function test_rebalance_allowlistEnabled_rejectsPartiallyZeroWeights() public {
-        // Non-allowlisted token must have ALL three weight components zero
-        address[] memory tokensToAdd = new address[](2);
-        tokensToAdd[0] = address(USDC);
-        tokensToAdd[1] = address(DAI);
-
-        vm.startPrank(owner);
-        folio.addToAllowlist(tokensToAdd);
-        folio.setTradeAllowlistEnabled(true);
-        vm.stopPrank();
-
-        // MEME with only low non-zero
-        IFolio.WeightRange memory lowOnly = IFolio.WeightRange({ low: 1e36, spot: 0, high: 0 });
-
-        IFolio.TokenRebalanceParams[] memory tokens = new IFolio.TokenRebalanceParams[](3);
-        tokens[0] = IFolio.TokenRebalanceParams(assets[0], weights[0], prices[0], type(uint256).max, true);
-        tokens[1] = IFolio.TokenRebalanceParams(assets[1], weights[1], prices[1], type(uint256).max, true);
-        tokens[2] = IFolio.TokenRebalanceParams(assets[2], lowOnly, prices[2], type(uint256).max, true);
+        tokens[2] = IFolio.TokenRebalanceParams(assets[2], SELL, prices[2], type(uint256).max, true);
 
         uint256 rebalanceNonceForExpectedRevert20 = nextRebalanceNonce(folio);
         vm.prank(dao);
@@ -378,45 +352,11 @@ contract AllowlistTest is BaseTest {
             MAX_TTL,
             type(uint256).max
         );
-
-        // Also test with only high non-zero
-        IFolio.WeightRange memory highOnly = IFolio.WeightRange({ low: 0, spot: 0, high: 1e36 });
-
-        tokens[2] = IFolio.TokenRebalanceParams(assets[2], highOnly, prices[2], type(uint256).max, true);
-
-        uint256 rebalanceNonceForExpectedRevert21 = nextRebalanceNonce(folio);
-        vm.prank(dao);
-        vm.expectRevert(IFolio.Folio__TokenNotAllowlisted.selector);
-        folio.startRebalance(
-            rebalanceNonceForExpectedRevert21,
-            tokens,
-            limits,
-            AUCTION_LAUNCHER_WINDOW,
-            MAX_TTL,
-            type(uint256).max
-        );
-
-        // Also test with only spot non-zero
-        IFolio.WeightRange memory spotOnly = IFolio.WeightRange({ low: 0, spot: 1e36, high: 0 });
-
-        tokens[2] = IFolio.TokenRebalanceParams(assets[2], spotOnly, prices[2], type(uint256).max, true);
-
-        uint256 rebalanceNonceForExpectedRevert22 = nextRebalanceNonce(folio);
-        vm.prank(dao);
-        vm.expectRevert(IFolio.Folio__TokenNotAllowlisted.selector);
-        folio.startRebalance(
-            rebalanceNonceForExpectedRevert22,
-            tokens,
-            limits,
-            AUCTION_LAUNCHER_WINDOW,
-            MAX_TTL,
-            type(uint256).max
-        );
     }
 
     // ========== Token Removed from Allowlist ==========
 
-    function test_rebalance_tokenRemovedFromAllowlist_canTradeOut() public {
+    function test_rebalance_tokenRemovedFromAllowlist_cannotBeTraded() public {
         // Add all tokens to allowlist initially
         address[] memory tokensToAdd = new address[](3);
         tokensToAdd[0] = address(USDC);
@@ -435,47 +375,17 @@ contract AllowlistTest is BaseTest {
 
         assertFalse(folio.isTokenAllowlisted(address(MEME)), "MEME should not be allowlisted");
 
-        // Rebalance with MEME having zero weights (trade out) -- should succeed
+        // Removing MEME prevents it from being included even with zero target weights
         IFolio.TokenRebalanceParams[] memory tokens = new IFolio.TokenRebalanceParams[](3);
         tokens[0] = IFolio.TokenRebalanceParams(assets[0], weights[0], prices[0], type(uint256).max, true);
         tokens[1] = IFolio.TokenRebalanceParams(assets[1], weights[1], prices[1], type(uint256).max, true);
         tokens[2] = IFolio.TokenRebalanceParams(assets[2], SELL, prices[2], type(uint256).max, true);
 
-        vm.prank(dao);
-        startRebalance(folio, tokens, limits, AUCTION_LAUNCHER_WINDOW, MAX_TTL);
-
-        (uint256 nonce, , , , , ) = folio.getRebalance();
-        assertEq(nonce, 1, "rebalance should have started");
-    }
-
-    function test_rebalance_tokenRemovedFromAllowlist_cannotIncreaseHolding() public {
-        // Add all tokens to allowlist initially
-        address[] memory tokensToAdd = new address[](3);
-        tokensToAdd[0] = address(USDC);
-        tokensToAdd[1] = address(DAI);
-        tokensToAdd[2] = address(MEME);
-
-        vm.startPrank(owner);
-        folio.addToAllowlist(tokensToAdd);
-        folio.setTradeAllowlistEnabled(true);
-
-        // Remove MEME from allowlist
-        address[] memory tokensToRemove = new address[](1);
-        tokensToRemove[0] = address(MEME);
-        folio.removeFromAllowlist(tokensToRemove);
-        vm.stopPrank();
-
-        // Rebalance with MEME having non-zero weights (trying to buy) -- should revert
-        IFolio.TokenRebalanceParams[] memory tokens = new IFolio.TokenRebalanceParams[](3);
-        tokens[0] = IFolio.TokenRebalanceParams(assets[0], weights[0], prices[0], type(uint256).max, true);
-        tokens[1] = IFolio.TokenRebalanceParams(assets[1], weights[1], prices[1], type(uint256).max, true);
-        tokens[2] = IFolio.TokenRebalanceParams(assets[2], weights[2], prices[2], type(uint256).max, true);
-
-        uint256 rebalanceNonceForExpectedRevert23 = nextRebalanceNonce(folio);
+        uint256 rebalanceNonceForExpectedRevert21 = nextRebalanceNonce(folio);
         vm.prank(dao);
         vm.expectRevert(IFolio.Folio__TokenNotAllowlisted.selector);
         folio.startRebalance(
-            rebalanceNonceForExpectedRevert23,
+            rebalanceNonceForExpectedRevert21,
             tokens,
             limits,
             AUCTION_LAUNCHER_WINDOW,
@@ -496,7 +406,7 @@ contract AllowlistTest is BaseTest {
         folio.setTradeAllowlistEnabled(true);
         vm.stopPrank();
 
-        // MEME is not allowlisted, rebalance with non-zero weights should fail
+        // MEME is not allowlisted, so it cannot be included in a rebalance
         IFolio.TokenRebalanceParams[] memory tokens = new IFolio.TokenRebalanceParams[](3);
         tokens[0] = IFolio.TokenRebalanceParams(assets[0], weights[0], prices[0], type(uint256).max, true);
         tokens[1] = IFolio.TokenRebalanceParams(assets[1], weights[1], prices[1], type(uint256).max, true);
@@ -541,7 +451,7 @@ contract AllowlistTest is BaseTest {
         folio.setTradeAllowlistEnabled(true);
         vm.stopPrank();
 
-        // MEME not allowlisted with non-zero weights should fail
+        // MEME is not allowlisted, so it cannot be included in a rebalance
         IFolio.TokenRebalanceParams[] memory tokens = new IFolio.TokenRebalanceParams[](3);
         tokens[0] = IFolio.TokenRebalanceParams(assets[0], weights[0], prices[0], type(uint256).max, true);
         tokens[1] = IFolio.TokenRebalanceParams(assets[1], weights[1], prices[1], type(uint256).max, true);
@@ -563,7 +473,7 @@ contract AllowlistTest is BaseTest {
         vm.prank(owner);
         folio.setTradeAllowlistEnabled(false);
 
-        // Should now succeed even with MEME having non-zero weights
+        // Should now succeed with MEME included
         vm.prank(dao);
         startRebalance(folio, tokens, limits, AUCTION_LAUNCHER_WINDOW, MAX_TTL);
 
@@ -585,7 +495,7 @@ contract AllowlistTest is BaseTest {
         folio.setTradeAllowlistEnabled(true);
         vm.stopPrank();
 
-        // Try to add USDT (not in allowlist) with non-zero weights
+        // Try to include USDT, which is not on the allowlist
         IFolio.TokenRebalanceParams[] memory tokens = new IFolio.TokenRebalanceParams[](4);
         tokens[0] = IFolio.TokenRebalanceParams(assets[0], SELL, prices[0], type(uint256).max, true);
         tokens[1] = IFolio.TokenRebalanceParams(assets[1], weights[1], prices[1], type(uint256).max, true);
@@ -657,7 +567,7 @@ contract AllowlistTest is BaseTest {
         folio.setTradeAllowlistEnabled(true);
         vm.stopPrank();
 
-        // MEME not allowlisted, non-zero weights should fail
+        // MEME is not allowlisted, so it cannot be included in a rebalance
         IFolio.TokenRebalanceParams[] memory tokens = new IFolio.TokenRebalanceParams[](3);
         tokens[0] = IFolio.TokenRebalanceParams(assets[0], weights[0], prices[0], type(uint256).max, true);
         tokens[1] = IFolio.TokenRebalanceParams(assets[1], weights[1], prices[1], type(uint256).max, true);
@@ -688,7 +598,7 @@ contract AllowlistTest is BaseTest {
         tokens[1] = IFolio.TokenRebalanceParams(assets[1], weights[1], prices[1], type(uint256).max, true);
         tokens[2] = IFolio.TokenRebalanceParams(assets[2], weights[2], prices[2], type(uint256).max, true);
 
-        // All tokens have non-zero weights but none are allowlisted
+        // No token can be included while the enabled allowlist is empty
         uint256 rebalanceNonceForExpectedRevert28 = nextRebalanceNonce(folio);
         vm.prank(dao);
         vm.expectRevert(IFolio.Folio__TokenNotAllowlisted.selector);
@@ -702,22 +612,28 @@ contract AllowlistTest is BaseTest {
         );
     }
 
-    function test_rebalance_emptyAllowlistEnabled_allZeroWeightsSucceeds() public {
+    function test_rebalance_emptyAllowlistEnabled_zeroWeightsAreRejected() public {
         // Enable allowlist without adding any tokens
         vm.prank(owner);
         folio.setTradeAllowlistEnabled(true);
 
-        // All tokens with zero weights (sell all) -- should succeed
+        // Zero target weights do not bypass an empty allowlist
         IFolio.TokenRebalanceParams[] memory tokens = new IFolio.TokenRebalanceParams[](3);
         tokens[0] = IFolio.TokenRebalanceParams(assets[0], SELL, prices[0], type(uint256).max, true);
         tokens[1] = IFolio.TokenRebalanceParams(assets[1], SELL, prices[1], type(uint256).max, true);
         tokens[2] = IFolio.TokenRebalanceParams(assets[2], SELL, prices[2], type(uint256).max, true);
 
+        uint256 rebalanceNonceForExpectedRevert29 = nextRebalanceNonce(folio);
         vm.prank(dao);
-        startRebalance(folio, tokens, limits, AUCTION_LAUNCHER_WINDOW, MAX_TTL);
-
-        (uint256 nonce, , , , , ) = folio.getRebalance();
-        assertEq(nonce, 1, "rebalance should have started");
+        vm.expectRevert(IFolio.Folio__TokenNotAllowlisted.selector);
+        folio.startRebalance(
+            rebalanceNonceForExpectedRevert29,
+            tokens,
+            limits,
+            AUCTION_LAUNCHER_WINDOW,
+            MAX_TTL,
+            type(uint256).max
+        );
     }
 
     // ========== Batch Operations ==========


### PR DESCRIPTION
## Summary

- redefine the token allowlist as the set of tokens safe to trade in new rebalances
- require every token passed to `startRebalance` to be allowlisted when enforcement is enabled
- remove the zero-weight exception and update focused tests and release documentation

## Verification

- `forge test --match-contract AllowlistTest`
- `pnpm format:check`
- `pnpm compile`
- `pnpm test:core`
- `pnpm test:extreme`
- `pnpm size`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Token trading allowlist controls now apply to every token included in a new rebalance.
  * Rebalances reject non-allowlisted tokens, including tokens with zero or partially zero target weights.
  * Tokens removed from the allowlist can no longer be included in rebalances.
* **Documentation**
  * Updated release notes and project documentation to clarify token trading allowlist behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->