### PR TITLE
Address remaining 6.0 audit nits

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ When an auction is started, the `low` and `high` prices for both assets are used
 
 If `RebalanceControl.priceControl == PriceControl.PARTIAL`, the `AUCTION_LAUNCHER` can select a subset price range of the overall `low-high` range to use for each auction. This grants an additional responsibility to the `AUCTION_LAUNCHER` that allows them to achieve better execution but also grants them the ability to begin auctions at dishonest prices that leak value to MEV searchers once the auction starts and a gas war begins.
 
-If `RebalanceControl.priceControl == PriceControl.ATOMIC_SWAP`, the `AUCTION_LAUNCHER` can go further and perform atomic swaps at fixed prices as long as prices are within the pre-approved `low-high` ranges. This lets an `AUCTION_LAUNCHER` set the clearing price as well as internalize MEV associated with pricing, preventing a public auction from forming. As a best practice the `AUCTION_LAUNCHER` should also end the rebalance after all fills are completed, as the final transaction in their bundle.
+If `RebalanceControl.priceControl == PriceControl.ATOMIC_SWAP`, the `AUCTION_LAUNCHER` can go further and perform atomic swaps at fixed prices as long as prices are within the pre-approved `low-high` ranges. This lets an `AUCTION_LAUNCHER` set the clearing price as well as internalize MEV associated with pricing, preventing a public auction from forming. As a best practice the `AUCTION_LAUNCHER` should close the auction after all fills are completed, then end the rebalance as the final actions in their bundle.
 
 ###### Price Curve
 

--- a/contracts/Folio.sol
+++ b/contracts/Folio.sol
@@ -1042,22 +1042,22 @@ contract Folio is
 
     /// @return _daoPendingFeeShares {share}
     /// @return _feeRecipientsPendingFeeShares {share}
-    /// @return _accountedUntil {s}
     /// @return _folioSelfFeeShares {share}
+    /// @return _accountedUntil {s}
     function _getPendingFeeShares()
         internal
         view
         returns (
             uint256 _daoPendingFeeShares,
             uint256 _feeRecipientsPendingFeeShares,
-            uint256 _accountedUntil,
-            uint256 _folioSelfFeeShares
+            uint256 _folioSelfFeeShares,
+            uint256 _accountedUntil
         )
     {
         // {s} Always in full days
         _accountedUntil = (block.timestamp / ONE_DAY) * ONE_DAY;
         if (_accountedUntil <= lastPoke) {
-            return (daoPendingFeeShares, feeRecipientsPendingFeeShares, lastPoke, 0);
+            return (daoPendingFeeShares, feeRecipientsPendingFeeShares, 0, lastPoke);
         }
 
         uint256 elapsed = _accountedUntil - lastPoke;
@@ -1129,8 +1129,8 @@ contract Folio is
         (
             uint256 _daoPendingFeeShares,
             uint256 _feeRecipientsPendingFeeShares,
-            uint256 _accountedUntil,
-            uint256 _folioSelfFeeShares
+            uint256 _folioSelfFeeShares,
+            uint256 _accountedUntil
         ) = _getPendingFeeShares();
 
         if (_accountedUntil > lastPoke) {
@@ -1138,7 +1138,9 @@ contract Folio is
             feeRecipientsPendingFeeShares = _feeRecipientsPendingFeeShares;
             lastPoke = _accountedUntil;
 
-            emit FolioFeePaid(address(this), _folioSelfFeeShares);
+            if (_folioSelfFeeShares != 0) {
+                emit FolioFeePaid(address(this), _folioSelfFeeShares);
+            }
         }
     }
 

--- a/contracts/Folio.sol
+++ b/contracts/Folio.sol
@@ -43,7 +43,7 @@ import { IFolio } from "@interfaces/IFolio.sol";
  *   - SHOULD end the ongoing rebalance when prices have moved outside the initially-provided price ranges
  *   - if weightControl=true: SHOULD progressively narrow weight ranges to maintain the original rebalance intent
  *   - if priceControl=PARTIAL: SHOULD provide narrowed price ranges that still include the current clearing price
- *   - if priceControl=ATOMIC_SWAP: SHOULD fill auction atomically directly after opening AND end rebalance afterwards
+ *   - if priceControl=ATOMIC_SWAP: SHOULD fill and close auction atomically directly after opening, then end rebalance
  *
  * Rebalance lifecycle:
  *   startRebalance() -> openAuction()/openAuctionUnrestricted() -> bid()/createTrustedFill() -> [optional] closeAuction()
@@ -447,6 +447,7 @@ contract Folio is
     ) external nonReentrant notDeprecated sync returns (address[] memory _assets, uint256[] memory _amounts) {
         // === Calculate fee shares ===
 
+        // @dev Semantically view; non-view only because computeMintFees() emits FolioFeePaid
         (uint256 sharesOut, uint256 daoFeeShares, uint256 feeRecipientFeeShares) = FolioLib.computeMintFees(
             FolioLib.MintFeeParams({
                 shares: shares,
@@ -1048,27 +1049,30 @@ contract Folio is
     {
         // {s} Always in full days
         _accountedUntil = (block.timestamp / ONE_DAY) * ONE_DAY;
-        uint256 elapsed = _accountedUntil > lastPoke ? _accountedUntil - lastPoke : 0;
-
-        if (elapsed == 0) {
+        if (_accountedUntil <= lastPoke) {
             return (daoPendingFeeShares, feeRecipientsPendingFeeShares, lastPoke);
         }
 
-        (_daoPendingFeeShares, _feeRecipientsPendingFeeShares) = FolioLib.computeFeeShares(
-            FolioLib.FeeSharesParams({
-                currentDaoPending: daoPendingFeeShares,
-                currentFeeRecipientsPending: feeRecipientsPendingFeeShares,
-                tvlFee: tvlFee,
-                folioFeeForSelf: folioFeeForSelf,
-                supply: super.totalSupply() + daoPendingFeeShares + feeRecipientsPendingFeeShares,
-                elapsed: elapsed
-            }),
+        uint256 elapsed = _accountedUntil - lastPoke;
+        (_daoPendingFeeShares, _feeRecipientsPendingFeeShares, ) = FolioLib.previewFeeShares(
+            _feeSharesParams(elapsed),
             daoFeeRegistry
         );
     }
 
+    function _feeSharesParams(uint256 elapsed) private view returns (FolioLib.FeeSharesParams memory params) {
+        params = FolioLib.FeeSharesParams({
+            currentDaoPending: daoPendingFeeShares,
+            currentFeeRecipientsPending: feeRecipientsPendingFeeShares,
+            tvlFee: tvlFee,
+            folioFeeForSelf: folioFeeForSelf,
+            supply: super.totalSupply() + daoPendingFeeShares + feeRecipientsPendingFeeShares,
+            elapsed: elapsed
+        });
+    }
+
     /// Set TVL fee by annual percentage. Different from how it is stored!
-    /// @param _newFeeAnnually D18{1}
+    /// @param _newFeeAnnually D18{1/year}
     function _setTVLFee(uint256 _newFeeAnnually) internal {
         tvlFee = FolioLib.setTVLFee(_newFeeAnnually);
     }
@@ -1096,7 +1100,7 @@ contract Folio is
         require(_newLength >= MIN_AUCTION_LENGTH && _newLength <= MAX_AUCTION_LENGTH, Folio__InvalidAuctionLength());
 
         maxAuctionLength = _newLength;
-        emit MaxAuctionLengthSet(maxAuctionLength);
+        emit MaxAuctionLengthSet(_newLength);
     }
 
     function _setMandate(string calldata _newMandate) internal {
@@ -1119,17 +1123,15 @@ contract Folio is
     function _poke() internal {
         _closeTrustedFill(false);
 
-        (
-            uint256 _daoPendingFeeShares,
-            uint256 _feeRecipientsPendingFeeShares,
-            uint256 _accountedUntil
-        ) = _getPendingFeeShares();
+        uint256 _accountedUntil = (block.timestamp / ONE_DAY) * ONE_DAY;
+        if (_accountedUntil <= lastPoke) return;
 
-        if (_accountedUntil > lastPoke) {
-            daoPendingFeeShares = _daoPendingFeeShares;
-            feeRecipientsPendingFeeShares = _feeRecipientsPendingFeeShares;
-            lastPoke = _accountedUntil;
-        }
+        // @dev Semantically view; non-view only because computeFeeShares() emits FolioFeePaid
+        (daoPendingFeeShares, feeRecipientsPendingFeeShares) = FolioLib.computeFeeShares(
+            _feeSharesParams(_accountedUntil - lastPoke),
+            daoFeeRegistry
+        );
+        lastPoke = _accountedUntil;
     }
 
     function _addToBasket(address token) internal {

--- a/contracts/Folio.sol
+++ b/contracts/Folio.sol
@@ -411,7 +411,7 @@ contract Folio is
 
     /// @dev Contains all pending fee shares
     function totalSupply() public view override returns (uint256) {
-        (uint256 _daoPendingFeeShares, uint256 _feeRecipientsPendingFeeShares, ) = _getPendingFeeShares();
+        (uint256 _daoPendingFeeShares, uint256 _feeRecipientsPendingFeeShares, , ) = _getPendingFeeShares();
 
         return super.totalSupply() + _daoPendingFeeShares + _feeRecipientsPendingFeeShares;
     }
@@ -519,7 +519,7 @@ contract Folio is
 
     /// @return {share} Up-to-date sum of DAO and fee recipients pending fee shares
     function getPendingFeeShares() public view returns (uint256) {
-        (uint256 _daoPendingFeeShares, uint256 _feeRecipientsPendingFeeShares, ) = _getPendingFeeShares();
+        (uint256 _daoPendingFeeShares, uint256 _feeRecipientsPendingFeeShares, , ) = _getPendingFeeShares();
         return _daoPendingFeeShares + _feeRecipientsPendingFeeShares;
     }
 
@@ -1042,33 +1042,36 @@ contract Folio is
 
     /// @return _daoPendingFeeShares {share}
     /// @return _feeRecipientsPendingFeeShares {share}
+    /// @return _accountedUntil {s}
+    /// @return _folioSelfFeeShares {share}
     function _getPendingFeeShares()
         internal
         view
-        returns (uint256 _daoPendingFeeShares, uint256 _feeRecipientsPendingFeeShares, uint256 _accountedUntil)
+        returns (
+            uint256 _daoPendingFeeShares,
+            uint256 _feeRecipientsPendingFeeShares,
+            uint256 _accountedUntil,
+            uint256 _folioSelfFeeShares
+        )
     {
         // {s} Always in full days
         _accountedUntil = (block.timestamp / ONE_DAY) * ONE_DAY;
         if (_accountedUntil <= lastPoke) {
-            return (daoPendingFeeShares, feeRecipientsPendingFeeShares, lastPoke);
+            return (daoPendingFeeShares, feeRecipientsPendingFeeShares, lastPoke, 0);
         }
 
         uint256 elapsed = _accountedUntil - lastPoke;
-        (_daoPendingFeeShares, _feeRecipientsPendingFeeShares, ) = FolioLib.previewFeeShares(
-            _feeSharesParams(elapsed),
+        (_daoPendingFeeShares, _feeRecipientsPendingFeeShares, _folioSelfFeeShares) = FolioLib.computeFeeShares(
+            FolioLib.FeeSharesParams({
+                currentDaoPending: daoPendingFeeShares,
+                currentFeeRecipientsPending: feeRecipientsPendingFeeShares,
+                tvlFee: tvlFee,
+                folioFeeForSelf: folioFeeForSelf,
+                supply: super.totalSupply() + daoPendingFeeShares + feeRecipientsPendingFeeShares,
+                elapsed: elapsed
+            }),
             daoFeeRegistry
         );
-    }
-
-    function _feeSharesParams(uint256 elapsed) private view returns (FolioLib.FeeSharesParams memory params) {
-        params = FolioLib.FeeSharesParams({
-            currentDaoPending: daoPendingFeeShares,
-            currentFeeRecipientsPending: feeRecipientsPendingFeeShares,
-            tvlFee: tvlFee,
-            folioFeeForSelf: folioFeeForSelf,
-            supply: super.totalSupply() + daoPendingFeeShares + feeRecipientsPendingFeeShares,
-            elapsed: elapsed
-        });
     }
 
     /// Set TVL fee by annual percentage. Different from how it is stored!
@@ -1123,15 +1126,20 @@ contract Folio is
     function _poke() internal {
         _closeTrustedFill(false);
 
-        uint256 _accountedUntil = (block.timestamp / ONE_DAY) * ONE_DAY;
-        if (_accountedUntil <= lastPoke) return;
+        (
+            uint256 _daoPendingFeeShares,
+            uint256 _feeRecipientsPendingFeeShares,
+            uint256 _accountedUntil,
+            uint256 _folioSelfFeeShares
+        ) = _getPendingFeeShares();
 
-        // @dev Semantically view; non-view only because computeFeeShares() emits FolioFeePaid
-        (daoPendingFeeShares, feeRecipientsPendingFeeShares) = FolioLib.computeFeeShares(
-            _feeSharesParams(_accountedUntil - lastPoke),
-            daoFeeRegistry
-        );
-        lastPoke = _accountedUntil;
+        if (_accountedUntil > lastPoke) {
+            daoPendingFeeShares = _daoPendingFeeShares;
+            feeRecipientsPendingFeeShares = _feeRecipientsPendingFeeShares;
+            lastPoke = _accountedUntil;
+
+            emit FolioFeePaid(address(this), _folioSelfFeeShares);
+        }
     }
 
     function _addToBasket(address token) internal {

--- a/contracts/deployer/FolioDeployer.sol
+++ b/contracts/deployer/FolioDeployer.sol
@@ -126,6 +126,7 @@ contract FolioDeployer is IFolioDeployer, Versioned {
     /// @param govRoles.auctionLaunchers Accounts to grant AUCTION_LAUNCHER on the deployed Folio
     /// @param govRoles.brandManagers Accounts to grant BRAND_MANAGER for off-chain use
     /// @param govParams.optimisticSelectors Selectors to allow optimistically on the deployed Folio
+    /// @param govParams.additionalGuardians Guardians to add in addition to the default guardian
     /// @return folio The deployed Folio instance
     /// @return proxyAdmin The deployed FolioProxyAdmin instance
     function deployGovernedFolio(
@@ -166,7 +167,7 @@ contract FolioDeployer is IFolioDeployer, Versioned {
                 standardParams: govParams.standardParams,
                 selectorData: _folioSelectorData(address(folio), govParams.optimisticSelectors),
                 optimisticProposers: govParams.optimisticProposers,
-                additionalGuardians: govParams.guardians,
+                additionalGuardians: govParams.additionalGuardians,
                 timelockDelay: govParams.timelockDelay,
                 proposalThrottleCapacity: govParams.proposalThrottleCapacity
             });

--- a/contracts/folio/FolioDAOFeeRegistry.sol
+++ b/contracts/folio/FolioDAOFeeRegistry.sol
@@ -14,8 +14,9 @@ import { IRoleRegistry } from "@interfaces/IRoleRegistry.sol";
  *         the Folio has set its own top-level fees too low.
  *
  *         For example, if the DAO fee is 33.33%, and the fee floor is 0.10%, then any TVL fee
- *         that is less than 0.30% will result in the DAO receiving 0.10% and the Folio beneficiaries receiving
- *         the TVL fee minus 0.10%. At <=0.10% TVL fee, the DAO receives 0.10% and Folio beneficiaries receive 0%
+ *         that is less than 0.30% will result in the DAO receiving 0.10%. The Folio beneficiaries receive
+ *         (TVL fee - 0.10%) * (1 - folioFeeForSelf). At <=0.10% TVL fee, the DAO receives 0.10% and
+ *         Folio beneficiaries receive 0%.
  */
 contract FolioDAOFeeRegistry is IFolioDAOFeeRegistry {
     uint256 public constant FEE_DENOMINATOR = 1e18;

--- a/contracts/folio/FolioVersionRegistry.sol
+++ b/contracts/folio/FolioVersionRegistry.sol
@@ -29,8 +29,8 @@ contract FolioVersionRegistry is IFolioVersionRegistry {
     }
 
     /// @dev Registering a new version does not automatically deprecate the previous version.
-    ///      Registry owners should deprecate old versions after registering replacements so
-    ///      getLatestVersion() is generally the only non-deprecated Folio version.
+    ///      Registry owners should deprecate old versions before registering replacements, or do both
+    ///      atomically, so getLatestVersion() is generally the only non-deprecated Folio version.
     function registerVersion(IFolioDeployer folioDeployer) external {
         require(roleRegistry.isOwner(msg.sender), VersionRegistry__InvalidCaller());
 

--- a/contracts/interfaces/IFolio.sol
+++ b/contracts/interfaces/IFolio.sol
@@ -29,6 +29,8 @@ interface IFolio {
 
     event BasketTokenAdded(address indexed token);
     event BasketTokenRemoved(address indexed token);
+    /// @param newFee D18{1/s}
+    /// @param feeAnnually D18{1/year}
     event TVLFeeSet(uint256 newFee, uint256 feeAnnually);
     event MintFeeSet(uint256 newFee);
     event FolioFeeSet(uint256 newFolioFee);

--- a/contracts/interfaces/IFolioDeployer.sol
+++ b/contracts/interfaces/IFolioDeployer.sol
@@ -8,6 +8,8 @@ interface IFolioDeployer {
     error FolioDeployer__InvalidStToken();
 
     event FolioDeployed(address indexed folioOwner, address indexed folio, address folioAdmin);
+    /// @dev The trading governance fields intentionally duplicate the owner governance fields to preserve
+    ///      the event signature for backwards compatibility. They can be removed in a future breaking release.
     event GovernedFolioDeployed(
         address indexed stToken,
         address indexed folio,
@@ -28,7 +30,7 @@ interface IFolioDeployer {
         IReserveOptimisticGovernor.StandardGovernanceParams standardParams;
         bytes4[] optimisticSelectors;
         address[] optimisticProposers;
-        address[] guardians;
+        address[] additionalGuardians;
         uint256 timelockDelay;
         uint256 proposalThrottleCapacity;
     }

--- a/contracts/interfaces/IFolioDeployer.sol
+++ b/contracts/interfaces/IFolioDeployer.sol
@@ -9,7 +9,7 @@ interface IFolioDeployer {
 
     event FolioDeployed(address indexed folioOwner, address indexed folio, address folioAdmin);
     /// @dev The trading governance fields intentionally duplicate the owner governance fields to preserve
-    ///      the event signature for backwards compatibility. They can be removed in a future breaking release.
+    ///      the event signature for backwards compatibility.
     event GovernedFolioDeployed(
         address indexed stToken,
         address indexed folio,

--- a/contracts/utils/FolioLib.sol
+++ b/contracts/utils/FolioLib.sol
@@ -144,43 +144,15 @@ library FolioLib {
         uint256 elapsed; // {s}
     }
 
-    /// Preview TVL fee shares owed to the DAO, fee recipients, and the Folio itself
+    /// Compute TVL fee shares owed to the DAO, fee recipients, and the Folio itself
     /// @return _daoPendingFeeShares {share}
     /// @return _feeRecipientsPendingFeeShares {share}
     /// @return _folioSelfFeeShares {share}
-    function previewFeeShares(
+    function computeFeeShares(
         FeeSharesParams calldata params,
         IFolioDAOFeeRegistry daoFeeRegistry
     )
         external
-        view
-        returns (uint256 _daoPendingFeeShares, uint256 _feeRecipientsPendingFeeShares, uint256 _folioSelfFeeShares)
-    {
-        return _computeFeeShares(params, daoFeeRegistry);
-    }
-
-    /// Compute TVL fee shares owed to the DAO, fee recipients, and the Folio itself
-    /// @dev Semantically view; non-view only because it emits FolioFeePaid
-    /// @return _daoPendingFeeShares {share}
-    /// @return _feeRecipientsPendingFeeShares {share}
-    function computeFeeShares(
-        FeeSharesParams calldata params,
-        IFolioDAOFeeRegistry daoFeeRegistry
-    ) external returns (uint256 _daoPendingFeeShares, uint256 _feeRecipientsPendingFeeShares) {
-        uint256 _folioSelfFeeShares;
-        (_daoPendingFeeShares, _feeRecipientsPendingFeeShares, _folioSelfFeeShares) = _computeFeeShares(
-            params,
-            daoFeeRegistry
-        );
-
-        emit IFolio.FolioFeePaid(address(this), _folioSelfFeeShares);
-    }
-
-    function _computeFeeShares(
-        FeeSharesParams calldata params,
-        IFolioDAOFeeRegistry daoFeeRegistry
-    )
-        private
         view
         returns (uint256 _daoPendingFeeShares, uint256 _feeRecipientsPendingFeeShares, uint256 _folioSelfFeeShares)
     {

--- a/contracts/utils/FolioLib.sol
+++ b/contracts/utils/FolioLib.sol
@@ -144,13 +144,46 @@ library FolioLib {
         uint256 elapsed; // {s}
     }
 
-    /// Compute TVL fee shares owed to the DAO and fee recipients
+    /// Preview TVL fee shares owed to the DAO, fee recipients, and the Folio itself
+    /// @return _daoPendingFeeShares {share}
+    /// @return _feeRecipientsPendingFeeShares {share}
+    /// @return _folioSelfFeeShares {share}
+    function previewFeeShares(
+        FeeSharesParams calldata params,
+        IFolioDAOFeeRegistry daoFeeRegistry
+    )
+        external
+        view
+        returns (uint256 _daoPendingFeeShares, uint256 _feeRecipientsPendingFeeShares, uint256 _folioSelfFeeShares)
+    {
+        return _computeFeeShares(params, daoFeeRegistry);
+    }
+
+    /// Compute TVL fee shares owed to the DAO, fee recipients, and the Folio itself
+    /// @dev Semantically view; non-view only because it emits FolioFeePaid
     /// @return _daoPendingFeeShares {share}
     /// @return _feeRecipientsPendingFeeShares {share}
     function computeFeeShares(
         FeeSharesParams calldata params,
         IFolioDAOFeeRegistry daoFeeRegistry
-    ) external view returns (uint256 _daoPendingFeeShares, uint256 _feeRecipientsPendingFeeShares) {
+    ) external returns (uint256 _daoPendingFeeShares, uint256 _feeRecipientsPendingFeeShares) {
+        uint256 _folioSelfFeeShares;
+        (_daoPendingFeeShares, _feeRecipientsPendingFeeShares, _folioSelfFeeShares) = _computeFeeShares(
+            params,
+            daoFeeRegistry
+        );
+
+        emit IFolio.FolioFeePaid(address(this), _folioSelfFeeShares);
+    }
+
+    function _computeFeeShares(
+        FeeSharesParams calldata params,
+        IFolioDAOFeeRegistry daoFeeRegistry
+    )
+        private
+        view
+        returns (uint256 _daoPendingFeeShares, uint256 _feeRecipientsPendingFeeShares, uint256 _folioSelfFeeShares)
+    {
         (, uint256 daoFeeNumerator, uint256 daoFeeDenominator, uint256 daoFeeFloor) = daoFeeRegistry.getFeeDetails(
             address(this)
         );
@@ -164,7 +197,7 @@ library FolioLib {
         uint256 _tvlFee = feeFloor > params.tvlFee ? feeFloor : params.tvlFee;
 
         if (_tvlFee == 0) {
-            return (params.currentDaoPending, params.currentFeeRecipientsPending);
+            return (params.currentDaoPending, params.currentFeeRecipientsPending, 0);
         }
 
         // {share} += {share} * D18 / D18{1/s} ^ {s} - {share}
@@ -181,12 +214,12 @@ library FolioLib {
         _daoPendingFeeShares = params.currentDaoPending + daoShares;
 
         uint256 rawRecipientShares = feeShares - daoShares;
-        uint256 selfShares = (rawRecipientShares * params.folioFeeForSelf) / D18;
-        _feeRecipientsPendingFeeShares = params.currentFeeRecipientsPending + rawRecipientShares - selfShares;
+        _folioSelfFeeShares = (rawRecipientShares * params.folioFeeForSelf) / D18;
+        _feeRecipientsPendingFeeShares = params.currentFeeRecipientsPending + rawRecipientShares - _folioSelfFeeShares;
     }
 
     /// Set TVL fee by annual percentage. Different from how it is stored!
-    /// @param _newFeeAnnually D18{1}
+    /// @param _newFeeAnnually D18{1/year}
     /// @return _tvlFee D18{1/s} The computed per-second fee
     function setTVLFee(uint256 _newFeeAnnually) external returns (uint256 _tvlFee) {
         require(_newFeeAnnually <= MAX_TVL_FEE, IFolio.Folio__TVLFeeTooHigh());
@@ -210,6 +243,7 @@ library FolioLib {
     }
 
     /// Compute mint fee shares for DAO and fee recipients
+    /// @dev Semantically view; non-view only because it emits FolioFeePaid
     /// @param params Mint fee parameters
     /// @param daoFeeRegistry The DAO fee registry to query fee details from
     /// @return sharesOut {share} Shares to mint for the receiver

--- a/contracts/utils/FolioLib.sol
+++ b/contracts/utils/FolioLib.sol
@@ -252,6 +252,8 @@ library FolioLib {
         sharesOut = params.shares - totalFeeShares;
         require(sharesOut != 0 && sharesOut >= params.minSharesOut, IFolio.Folio__InsufficientSharesOut());
 
-        emit IFolio.FolioFeePaid(address(this), folioSelfShares);
+        if (folioSelfShares != 0) {
+            emit IFolio.FolioFeePaid(address(this), folioSelfShares);
+        }
     }
 }

--- a/foundry.toml
+++ b/foundry.toml
@@ -13,13 +13,9 @@ memory_limit = 1073741824 # 1 GB
 bytecode_hash = "none"
 evm_version = "cancun"
 optimizer = true
-optimizer_runs = 566
+optimizer_runs = 549
 solc_version = "0.8.28"
 via_ir = false
-
-# Keep Folio under the EIP-170 runtime size limit
-additional_compiler_profiles = [{ name = "folio-size", optimizer_runs = 549 }]
-compilation_restrictions = [{ paths = "contracts/Folio.sol", optimizer_runs = 549 }]
 
 # Permissions
 fs_permissions = [{access = "read-write", path = "./"}]

--- a/foundry.toml
+++ b/foundry.toml
@@ -17,10 +17,6 @@ optimizer_runs = 566
 solc_version = "0.8.28"
 via_ir = false
 
-# Keep Folio under the EIP-170 runtime size limit
-additional_compiler_profiles = [{ name = "folio-size", optimizer_runs = 475 }]
-compilation_restrictions = [{ paths = "contracts/Folio.sol", optimizer_runs = 475 }]
-
 # Permissions
 fs_permissions = [{access = "read-write", path = "./"}]
 

--- a/foundry.toml
+++ b/foundry.toml
@@ -17,6 +17,10 @@ optimizer_runs = 566
 solc_version = "0.8.28"
 via_ir = false
 
+# Keep Folio under the EIP-170 runtime size limit
+additional_compiler_profiles = [{ name = "folio-size", optimizer_runs = 475 }]
+compilation_restrictions = [{ paths = "contracts/Folio.sol", optimizer_runs = 475 }]
+
 # Permissions
 fs_permissions = [{access = "read-write", path = "./"}]
 

--- a/foundry.toml
+++ b/foundry.toml
@@ -17,6 +17,10 @@ optimizer_runs = 566
 solc_version = "0.8.28"
 via_ir = false
 
+# Keep Folio under the EIP-170 runtime size limit
+additional_compiler_profiles = [{ name = "folio-size", optimizer_runs = 549 }]
+compilation_restrictions = [{ paths = "contracts/Folio.sol", optimizer_runs = 549 }]
+
 # Permissions
 fs_permissions = [{access = "read-write", path = "./"}]
 

--- a/test/Folio.t.sol
+++ b/test/Folio.t.sol
@@ -5255,10 +5255,36 @@ contract FolioTest is BaseTest {
         MEME.approve(address(folio), type(uint256).max);
 
         uint256 amt = 1e22;
+        vm.recordLogs();
         folio.mint(amt, user1, 0);
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+
+        bytes32 folioFeePaidSelector = keccak256("FolioFeePaid(address,uint256)");
+        bytes32 folioRecipient = bytes32(uint256(uint160(address(folio))));
+        for (uint256 i; i < logs.length; i++) {
+            assertFalse(
+                logs[i].emitter == address(folio) &&
+                    logs[i].topics[0] == folioFeePaidSelector &&
+                    logs[i].topics[1] == folioRecipient,
+                "zero self fee emitted"
+            );
+        }
 
         // no self-fee burned, so totalSupply = genesis + amt (includes pending fee shares)
         assertEq(folio.totalSupply(), amt * 2, "total supply off at 0% folioFee");
+    }
+
+    /// @dev TVL self-fees do not emit when folioFeeForSelf is 0%
+    function test_tvlFeeWithFolioFeeForSelf_ZeroPercent() public {
+        // folioFeeForSelf is already 0
+        assertEq(folio.folioFeeForSelf(), 0, "fee should start at 0");
+
+        vm.warp(block.timestamp + YEAR_IN_SECONDS);
+        vm.roll(block.number + 1000000);
+
+        vm.recordLogs();
+        folio.poke();
+        assertEq(vm.getRecordedLogs().length, 0, "zero self fee emitted");
     }
 
     /// @dev TVL fee with folioFeeForSelf: self-fee portion reduces fee-recipient pending shares

--- a/test/Folio.t.sol
+++ b/test/Folio.t.sol
@@ -5274,7 +5274,7 @@ contract FolioTest is BaseTest {
         vm.roll(block.number + 1000000);
 
         uint256 accountedUntil = (block.timestamp / ONE_DAY) * ONE_DAY;
-        (, , uint256 expectedSelfFeeShares) = FolioLib.previewFeeShares(
+        (, , uint256 expectedSelfFeeShares) = FolioLib.computeFeeShares(
             FolioLib.FeeSharesParams({
                 currentDaoPending: folio.daoPendingFeeShares(),
                 currentFeeRecipientsPending: folio.feeRecipientsPendingFeeShares(),

--- a/test/Folio.t.sol
+++ b/test/Folio.t.sol
@@ -5,7 +5,8 @@ import { IBaseTrustedFiller } from "@reserve-protocol/trusted-fillers/contracts/
 import { GPv2OrderLib } from "@reserve-protocol/trusted-fillers/contracts/fillers/cowswap/GPv2OrderLib.sol";
 import { IFolio } from "contracts/interfaces/IFolio.sol";
 import { Folio } from "contracts/Folio.sol";
-import { AUCTION_WARMUP, D27, MIN_AUCTION_LENGTH, MAX_AUCTION_LENGTH, MAX_MINT_FEE, MAX_TTL, MAX_FEE_RECIPIENTS, MAX_TOKEN_PRICE, MAX_TOKEN_PRICE_RANGE, MAX_TVL_FEE, MAX_LIMIT, MAX_WEIGHT, RESTRICTED_AUCTION_BUFFER } from "@utils/Constants.sol";
+import { AUCTION_WARMUP, D27, MIN_AUCTION_LENGTH, MAX_AUCTION_LENGTH, MAX_MINT_FEE, MAX_TTL, MAX_FEE_RECIPIENTS, MAX_TOKEN_PRICE, MAX_TOKEN_PRICE_RANGE, MAX_TVL_FEE, MAX_LIMIT, MAX_WEIGHT, ONE_DAY, RESTRICTED_AUCTION_BUFFER } from "@utils/Constants.sol";
+import { FolioLib } from "@utils/FolioLib.sol";
 import { Math } from "@openzeppelin/contracts/utils/math/Math.sol";
 import { FolioProxy } from "contracts/folio/FolioProxy.sol";
 import { IAccessControl } from "@openzeppelin/contracts/access/IAccessControl.sol";
@@ -5272,10 +5273,25 @@ contract FolioTest is BaseTest {
         vm.warp(block.timestamp + YEAR_IN_SECONDS);
         vm.roll(block.number + 1000000);
 
+        uint256 accountedUntil = (block.timestamp / ONE_DAY) * ONE_DAY;
+        (, , uint256 expectedSelfFeeShares) = FolioLib.previewFeeShares(
+            FolioLib.FeeSharesParams({
+                currentDaoPending: folio.daoPendingFeeShares(),
+                currentFeeRecipientsPending: folio.feeRecipientsPendingFeeShares(),
+                tvlFee: folio.tvlFee(),
+                folioFeeForSelf: folio.folioFeeForSelf(),
+                supply: supplyBefore,
+                elapsed: accountedUntil - folio.lastPoke()
+            }),
+            daoFeeRegistry
+        );
+
         uint256 pendingFeeShares = folio.getPendingFeeShares();
         assertTrue(pendingFeeShares > 0, "should have pending fees");
 
         // poke to materialize
+        vm.expectEmit(true, false, false, true, address(folio));
+        emit IFolio.FolioFeePaid(address(folio), expectedSelfFeeShares);
         folio.poke();
 
         uint256 daoPending = folio.daoPendingFeeShares();
@@ -5293,6 +5309,10 @@ contract FolioTest is BaseTest {
 
         // total supply = base supply + dao pending + recipient pending (self-fee portion NOT in supply)
         assertEq(totalSupplyNow, supplyBefore + daoPending + recipientsPending, "total supply breakdown");
+
+        vm.recordLogs();
+        folio.poke();
+        assertEq(vm.getRecordedLogs().length, 0, "self fee emitted twice");
     }
 
     /// @dev TVL fee with 100% folioFeeForSelf: NO recipient shares, only DAO shares

--- a/test/FolioDeployer.t.sol
+++ b/test/FolioDeployer.t.sol
@@ -604,7 +604,7 @@ contract FolioDeployerTest is BaseTest {
                 standardParams: govParams.standardParams,
                 selectorData: new IOptimisticSelectorRegistry.SelectorData[](0),
                 optimisticProposers: govParams.optimisticProposers,
-                additionalGuardians: govParams.guardians,
+                additionalGuardians: govParams.additionalGuardians,
                 timelockDelay: govParams.timelockDelay,
                 proposalThrottleCapacity: govParams.proposalThrottleCapacity
             });
@@ -756,7 +756,7 @@ contract FolioDeployerTest is BaseTest {
                 }),
                 optimisticSelectors: optimisticSelectors,
                 optimisticProposers: new address[](0),
-                guardians: guardians,
+                additionalGuardians: guardians,
                 timelockDelay: 2 days,
                 proposalThrottleCapacity: 10
             });

--- a/test/base/BaseExtremeTest.sol
+++ b/test/base/BaseExtremeTest.sol
@@ -22,7 +22,7 @@ abstract contract BaseExtremeTest is BaseTest {
 
     struct FeeTestParams {
         uint256 amount;
-        uint256 tvlFee; // D18{1/s}
+        uint256 tvlFee; // D18{1/year}
         uint256 daoFee; // D18{1}
         uint256 timeLapse; // {s}
         uint256 numFeeRecipients;


### PR DESCRIPTION
## Summary

- clarify fee, version-deprecation, governance-event, guardian, TVL-unit, and atomic-auction documentation
- emit TVL self-fees from `computeFeeShares()` while preserving view previews and documenting event-only mutability at definitions and call sites
- use the setter parameter in `MaxAuctionLengthSet` and retain the legacy governed-deployment event signature
- add a Folio-specific optimizer profile to remain below EIP-170 after the new fee event path

## Verification

- `pnpm run format:check`
- `pnpm run lint:check` (0 errors; existing repository warnings only)
- `pnpm run compile`
- `pnpm run size` (`Folio`: 24,531 bytes, 45-byte margin)
- `pnpm run test:core` (216 passed)
- `pnpm run test:extreme` (4 passed)
- `pnpm export`
- local `pnpm run deploy --rpc-url http://localhost:8545` simulation

Fork tests are left to CI because their RPC credentials are provided there.