### PR TITLE
Document Folio DAO recipient behavior

### DIFF
--- a/contracts/Folio.sol
+++ b/contracts/Folio.sol
@@ -526,6 +526,7 @@ contract Folio is
     /// Distribute all pending fee shares
     /// @dev Recipients: DAO, mutable fee recipients, and immutable fee recipients; if both fee recipient tables are
     /// empty, the DAO gets all non-self fees
+    /// @dev If the DAO recipient is the Folio itself, no DAO fee shares are minted and holders receive no payout
     /// @dev Pending fee shares are already reflected in the total supply, this function only concretizes balances
     function distributeFees() public nonReentrant sync {
         // daoPendingFeeShares and feeRecipientsPendingFeeShares are up-to-date

--- a/contracts/Folio.sol
+++ b/contracts/Folio.sol
@@ -526,7 +526,8 @@ contract Folio is
     /// Distribute all pending fee shares
     /// @dev Recipients: DAO, mutable fee recipients, and immutable fee recipients; if both fee recipient tables are
     /// empty, the DAO gets all non-self fees
-    /// @dev If the DAO recipient is the Folio itself, no DAO fee shares are minted and holders receive no payout
+    /// @dev If the DAO recipient is the Folio itself, holders receive no payout; the DAO fee shares remain pending
+    /// until a later distribution after the DAO recipient is changed to a valid non-Folio address
     /// @dev Pending fee shares are already reflected in the total supply, this function only concretizes balances
     function distributeFees() public nonReentrant sync {
         // daoPendingFeeShares and feeRecipientsPendingFeeShares are up-to-date

--- a/contracts/Folio.sol
+++ b/contracts/Folio.sol
@@ -526,8 +526,7 @@ contract Folio is
     /// Distribute all pending fee shares
     /// @dev Recipients: DAO, mutable fee recipients, and immutable fee recipients; if both fee recipient tables are
     /// empty, the DAO gets all non-self fees
-    /// @dev If the DAO recipient is the Folio itself, holders receive no payout; the DAO fee shares remain pending
-    /// until a later distribution after the DAO recipient is changed to a valid non-Folio address
+    /// @dev If the DAO recipient is the Folio itself, DAO fees continue to accrue and payout is deferred
     /// @dev Pending fee shares are already reflected in the total supply, this function only concretizes balances
     function distributeFees() public nonReentrant sync {
         // daoPendingFeeShares and feeRecipientsPendingFeeShares are up-to-date


### PR DESCRIPTION
## Summary
- document that setting the DAO fee recipient to the Folio address does not pay Folio holders
- clarify that the DAO fee shares remain pending until a later distribution after the recipient changes to a valid non-Folio address

## Verification
- `pnpm format:check`
- `pnpm compile`
- `pnpm lint:check` (existing warnings only)