### PR TITLE
Defer mint self-fees to daily settlement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,8 @@
 - Add optimistic governance
 - Add optional token trading allowlist controls (`DEFAULT_ADMIN_ROLE`). Enforcement is disabled by default; when
   enabled, every token included in a new rebalance, including zero-weight tokens, must be allowlisted.
-- Add Folio self-fee (`DEFAULT_ADMIN_ROLE`). On mint, the receiver participates in the resulting exchange-rate
-  appreciation and recovers a size-dependent portion of the self-fee; see `folioFeeForSelf` in the README.
+- Add Folio self-fee (`DEFAULT_ADMIN_ROLE`). Mint self-fees remain in the effective supply until the next daily fee
+  settlement, keeping mints exchange-rate neutral; see `folioFeeForSelf` in the README.
 - Add Folio immutable fee recipients (`DEFAULT_ADMIN_ROLE`)
 - Add per-auction custom auction lengths (`AUCTION_LAUNCHER`, within admin-configured max length)
 - Add explicit rebalance nonce validation

--- a/README.md
+++ b/README.md
@@ -188,11 +188,9 @@ Max: 5%
 
 **Fraction of non-DAO fee value directed to Folio holders**
 
-`folioFeeForSelf` applies to the fee-recipient portion of both TVL fees and mint fees. Instead of minting the configured fraction of fee-recipient shares, the Folio omits those shares from its supply. The underlying assets remain in the Folio, increasing the assets represented by each outstanding share.
+`folioFeeForSelf` applies to the fee-recipient portion of both TVL fees and mint fees. Instead of minting the configured fraction of fee-recipient shares, the Folio omits those shares from its supply at the next daily fee settlement. The underlying assets remain in the Folio, increasing the assets represented by each outstanding share.
 
-For mint fees, the receiver still receives `shares - totalFeeShares`, including a deduction for the omitted self-fee shares. However, those newly minted receiver shares immediately participate in the resulting exchange-rate increase. The receiver therefore recovers a portion of the self-fee value equal to its newly minted fraction of the post-mint supply, subject to rounding. The effect is small for mints that are small relative to the existing supply and increases with the relative size of the mint. The DAO fee portion, including the minimum DAO fee floor, is minted separately and is not recovered through this effect.
-
-Breaking a large mint into smaller sequential mints results in a smaller overall rebate, apart from rounding and fee-floor edge effects, because later tranches do not participate in the appreciation caused by earlier mints. Separately, an account that becomes a holder immediately before another account's mint and redeems afterward can capture a portion of that mint's self-fee.
+For mint fees, the receiver still receives `shares - totalFeeShares`, including a deduction for the self-fee shares. Those self-fee shares remain part of the effective supply until the next daily fee settlement, keeping the mint exchange-rate neutral apart from asset-transfer rounding. At settlement, the self-fee shares are omitted from the supply and their value is directed to the holders at that time. The DAO fee portion, including the minimum DAO fee floor, is minted separately.
 
 #### Fee Floor
 

--- a/contracts/Folio.sol
+++ b/contracts/Folio.sol
@@ -193,6 +193,7 @@ contract Folio is
     uint256 public folioFeeForSelf; // D18{1} fraction of fee-recipient shares to burn
 
     FeeRecipient[] public immutableFeeRecipients;
+    uint256 public folioPendingFeeShares; // {share} Folio self-fee shares pending daily settlement
 
     /// Any external call to the Folio that relies on accurate share accounting must pre-hook poke
     modifier sync() {
@@ -411,9 +412,16 @@ contract Folio is
 
     /// @dev Contains all pending fee shares
     function totalSupply() public view override returns (uint256) {
-        (uint256 _daoPendingFeeShares, uint256 _feeRecipientsPendingFeeShares, , ) = _getPendingFeeShares();
+        (
+            uint256 _daoPendingFeeShares,
+            uint256 _feeRecipientsPendingFeeShares,
+            ,
+            uint256 _accountedUntil
+        ) = _getPendingFeeShares();
 
-        return super.totalSupply() + _daoPendingFeeShares + _feeRecipientsPendingFeeShares;
+        uint256 _folioPendingFeeShares = _accountedUntil == lastPoke ? folioPendingFeeShares : 0;
+
+        return super.totalSupply() + _daoPendingFeeShares + _feeRecipientsPendingFeeShares + _folioPendingFeeShares;
     }
 
     /// @dev Result may be unreliable mid-swap during trusted fill execution, check stateChangeActive()
@@ -476,6 +484,7 @@ contract Folio is
         // defer fee handouts until distributeFees()
         daoPendingFeeShares += daoFeeShares;
         feeRecipientsPendingFeeShares += feeRecipientFeeShares;
+        folioPendingFeeShares += shares - sharesOut - daoFeeShares - feeRecipientFeeShares;
     }
 
     /// @param shares {share} Amount of shares to redeem
@@ -1061,17 +1070,43 @@ contract Folio is
         }
 
         uint256 elapsed = _accountedUntil - lastPoke;
+        uint256 firstElapsed = elapsed;
+        if (folioPendingFeeShares != 0) {
+            uint256 nextBoundary = ((lastPoke / ONE_DAY) + 1) * ONE_DAY;
+            firstElapsed = Math.min(elapsed, nextBoundary - lastPoke);
+        }
+
         (_daoPendingFeeShares, _feeRecipientsPendingFeeShares, _folioSelfFeeShares) = FolioLib.computeFeeShares(
             FolioLib.FeeSharesParams({
                 currentDaoPending: daoPendingFeeShares,
                 currentFeeRecipientsPending: feeRecipientsPendingFeeShares,
                 tvlFee: tvlFee,
                 folioFeeForSelf: folioFeeForSelf,
-                supply: super.totalSupply() + daoPendingFeeShares + feeRecipientsPendingFeeShares,
-                elapsed: elapsed
+                supply: super.totalSupply() +
+                    daoPendingFeeShares +
+                    feeRecipientsPendingFeeShares +
+                    folioPendingFeeShares,
+                elapsed: firstElapsed
             }),
             daoFeeRegistry
         );
+
+        // mint self-fees settle at the first boundary; exclude them from any remaining TVL fee period
+        if (firstElapsed != elapsed) {
+            uint256 firstFolioSelfFeeShares = _folioSelfFeeShares;
+            (_daoPendingFeeShares, _feeRecipientsPendingFeeShares, _folioSelfFeeShares) = FolioLib.computeFeeShares(
+                FolioLib.FeeSharesParams({
+                    currentDaoPending: _daoPendingFeeShares,
+                    currentFeeRecipientsPending: _feeRecipientsPendingFeeShares,
+                    tvlFee: tvlFee,
+                    folioFeeForSelf: folioFeeForSelf,
+                    supply: super.totalSupply() + _daoPendingFeeShares + _feeRecipientsPendingFeeShares,
+                    elapsed: elapsed - firstElapsed
+                }),
+                daoFeeRegistry
+            );
+            _folioSelfFeeShares += firstFolioSelfFeeShares;
+        }
     }
 
     /// Set TVL fee by annual percentage. Different from how it is stored!
@@ -1136,6 +1171,7 @@ contract Folio is
         if (_accountedUntil > lastPoke) {
             daoPendingFeeShares = _daoPendingFeeShares;
             feeRecipientsPendingFeeShares = _feeRecipientsPendingFeeShares;
+            folioPendingFeeShares = 0;
             lastPoke = _accountedUntil;
 
             if (_folioSelfFeeShares != 0) {

--- a/foundry.toml
+++ b/foundry.toml
@@ -13,7 +13,7 @@ memory_limit = 1073741824 # 1 GB
 bytecode_hash = "none"
 evm_version = "cancun"
 optimizer = true
-optimizer_runs = 549
+optimizer_runs = 50
 solc_version = "0.8.28"
 via_ir = false
 

--- a/test/Folio.t.sol
+++ b/test/Folio.t.sol
@@ -5158,7 +5158,7 @@ contract FolioTest is BaseTest {
         assertTrue(folio.balanceOf(dao) > initialDaoShares, "dao should have received fees");
     }
 
-    /// @dev With folioFeeForSelf at 50%, half of the fee-recipient shares on mint should be burned
+    /// @dev With folioFeeForSelf at 50%, half of the fee-recipient shares on mint should await settlement
     function test_mintWithFolioFeeForSelf() public {
         // set folioFeeForSelf to 50%
         vm.prank(owner);
@@ -5184,7 +5184,7 @@ contract FolioTest is BaseTest {
         uint256 daoFeeShares = (totalFeeShares * MAX_DAO_FEE + 1e18 - 1) / 1e18;
         // recipientRaw = totalFeeShares - daoFeeShares
         uint256 recipientRaw = totalFeeShares - daoFeeShares;
-        // selfShares (burned) = recipientRaw * 50%
+        // selfShares (pending settlement) = recipientRaw * 50%
         uint256 selfShares = (recipientRaw * 0.5e18) / 1e18;
         uint256 expectedFeeRecipientShares = recipientRaw - selfShares;
 
@@ -5192,9 +5192,9 @@ contract FolioTest is BaseTest {
         uint256 expectedSharesOut = amt - totalFeeShares;
         assertEq(folio.balanceOf(user1), expectedSharesOut, "wrong user shares out");
 
-        // total supply: genesis + sharesOut + daoFee + feeRecipientFee (self-fee NOT minted)
-        uint256 expectedTotalSupply = INITIAL_SUPPLY + expectedSharesOut + daoFeeShares + expectedFeeRecipientShares;
-        assertEq(folio.totalSupply(), expectedTotalSupply, "wrong total supply with folioFeeForSelf");
+        // pending self-fees remain in effective supply until daily settlement
+        assertEq(folio.folioPendingFeeShares(), selfShares, "wrong pending folio fee shares");
+        assertEq(folio.totalSupply(), INITIAL_SUPPLY + amt, "wrong total supply with folioFeeForSelf");
 
         assertEq(folio.daoPendingFeeShares(), daoFeeShares, "wrong dao pending fee shares");
         assertEq(
@@ -5204,7 +5204,7 @@ contract FolioTest is BaseTest {
         );
     }
 
-    /// @dev With folioFeeForSelf at 100%, ALL fee-recipient shares on mint are burned
+    /// @dev With folioFeeForSelf at 100%, ALL fee-recipient shares on mint await settlement
     function test_mintWithFolioFeeForSelf_100Percent() public {
         // set folioFeeForSelf to 100%
         vm.prank(owner);
@@ -5228,16 +5228,148 @@ contract FolioTest is BaseTest {
         uint256 totalFeeShares = (amt * MAX_MINT_FEE + 1e18 - 1) / 1e18;
         uint256 daoFeeShares = (totalFeeShares * MAX_DAO_FEE + 1e18 - 1) / 1e18;
 
-        // ALL fee-recipient shares are burned (folioFeeForSelf = 100%)
+        // ALL fee-recipient shares await settlement (folioFeeForSelf = 100%)
         assertEq(folio.feeRecipientsPendingFeeShares(), 0, "fee recipients should get 0 with 100% folioFee");
         assertEq(folio.daoPendingFeeShares(), daoFeeShares, "wrong dao pending fee shares");
+        assertEq(folio.folioPendingFeeShares(), totalFeeShares - daoFeeShares, "wrong pending folio fee shares");
 
         uint256 expectedSharesOut = amt - totalFeeShares;
         assertEq(folio.balanceOf(user1), expectedSharesOut, "wrong user shares out");
 
-        // total supply = genesis + sharesOut + daoFee (no fee-recipient shares minted)
-        uint256 expectedTotalSupply = INITIAL_SUPPLY + expectedSharesOut + daoFeeShares;
-        assertEq(folio.totalSupply(), expectedTotalSupply, "wrong total supply");
+        assertEq(folio.totalSupply(), INITIAL_SUPPLY + amt, "wrong total supply");
+    }
+
+    function test_mintWithFolioFeeForSelf_isExchangeRateNeutral() public {
+        vm.startPrank(owner);
+        folio.setFolioSelfFee(0.5e18);
+        folio.setMintFee(MAX_MINT_FEE);
+        vm.stopPrank();
+
+        (, uint256[] memory amountsBefore) = folio.toAssets(1e18, Math.Rounding.Floor);
+
+        vm.startPrank(user1);
+        USDC.approve(address(folio), type(uint256).max);
+        DAI.approve(address(folio), type(uint256).max);
+        MEME.approve(address(folio), type(uint256).max);
+        folio.mint(INITIAL_SUPPLY, user1, 0);
+        vm.stopPrank();
+
+        (, uint256[] memory amountsAfter) = folio.toAssets(1e18, Math.Rounding.Floor);
+        assertEq(amountsAfter, amountsBefore, "mint changed exchange rate");
+        assertEq(folio.totalSupply(), INITIAL_SUPPLY * 2, "mint did not add gross shares to effective supply");
+    }
+
+    function test_mintWithFolioFeeForSelf_accumulatesAcrossMints() public {
+        vm.startPrank(owner);
+        folio.setFolioSelfFee(0.5e18);
+        folio.setMintFee(MAX_MINT_FEE);
+        vm.stopPrank();
+
+        vm.startPrank(user1);
+        USDC.approve(address(folio), type(uint256).max);
+        DAI.approve(address(folio), type(uint256).max);
+        MEME.approve(address(folio), type(uint256).max);
+
+        uint256 amount = INITIAL_SUPPLY / 10;
+        folio.mint(amount, user1, 0);
+        uint256 pendingAfterFirstMint = folio.folioPendingFeeShares();
+        folio.mint(amount, user1, 0);
+        vm.stopPrank();
+
+        assertEq(folio.folioPendingFeeShares(), pendingAfterFirstMint * 2, "self-fees did not accumulate");
+        assertEq(folio.totalSupply(), INITIAL_SUPPLY + amount * 2, "mints changed effective exchange rate");
+    }
+
+    function test_mintWithFolioFeeForSelf_settlesAtDailyBoundary() public {
+        daoFeeRegistry.setDefaultFeeFloor(0);
+
+        vm.startPrank(owner);
+        folio.setTVLFee(0);
+        folio.setFolioSelfFee(0.5e18);
+        folio.setMintFee(MAX_MINT_FEE);
+        vm.stopPrank();
+
+        vm.startPrank(user1);
+        USDC.approve(address(folio), type(uint256).max);
+        DAI.approve(address(folio), type(uint256).max);
+        MEME.approve(address(folio), type(uint256).max);
+        folio.mint(INITIAL_SUPPLY, user1, 0);
+        vm.stopPrank();
+
+        uint256 pendingSelfFees = folio.folioPendingFeeShares();
+        uint256 supplyBeforeSettlement = folio.totalSupply();
+        assertTrue(pendingSelfFees > 0, "missing pending self-fees");
+
+        vm.warp(((block.timestamp / ONE_DAY) + 1) * ONE_DAY);
+
+        // View accounting settles at the boundary even before state is poked.
+        assertEq(folio.totalSupply(), supplyBeforeSettlement - pendingSelfFees, "self-fees not settled in supply");
+        assertEq(folio.folioPendingFeeShares(), pendingSelfFees, "view accounting changed storage");
+
+        folio.poke();
+        assertEq(folio.folioPendingFeeShares(), 0, "poke did not clear settled self-fees");
+        assertEq(folio.totalSupply(), supplyBeforeSettlement - pendingSelfFees, "poke changed settled supply");
+    }
+
+    function test_distributeFees_doesNotSettleMintSelfFeesBeforeDailyBoundary() public {
+        vm.startPrank(owner);
+        folio.setFolioSelfFee(0.5e18);
+        folio.setMintFee(MAX_MINT_FEE);
+        vm.stopPrank();
+
+        vm.startPrank(user1);
+        USDC.approve(address(folio), type(uint256).max);
+        DAI.approve(address(folio), type(uint256).max);
+        MEME.approve(address(folio), type(uint256).max);
+        folio.mint(INITIAL_SUPPLY, user1, 0);
+        vm.stopPrank();
+
+        uint256 pendingSelfFees = folio.folioPendingFeeShares();
+        uint256 supplyBeforeDistribution = folio.totalSupply();
+        folio.distributeFees();
+
+        assertEq(folio.folioPendingFeeShares(), pendingSelfFees, "distribution settled self-fees early");
+        assertEq(folio.totalSupply(), supplyBeforeDistribution, "distribution changed effective supply");
+    }
+
+    function test_mintSelfFees_delayedPokeMatchesFirstBoundaryPoke() public {
+        vm.startPrank(owner);
+        folio.setFolioSelfFee(0.5e18);
+        folio.setMintFee(MAX_MINT_FEE);
+        vm.stopPrank();
+
+        vm.startPrank(user1);
+        USDC.approve(address(folio), type(uint256).max);
+        DAI.approve(address(folio), type(uint256).max);
+        MEME.approve(address(folio), type(uint256).max);
+        folio.mint(INITIAL_SUPPLY, user1, 0);
+        vm.stopPrank();
+
+        uint256 firstBoundary = ((block.timestamp / ONE_DAY) + 1) * ONE_DAY;
+        uint256 finalBoundary = firstBoundary + 30 * ONE_DAY;
+        uint256 snapshot = vm.snapshotState();
+
+        vm.warp(firstBoundary);
+        folio.poke();
+        vm.warp(finalBoundary);
+        folio.poke();
+
+        uint256 expectedDaoPending = folio.daoPendingFeeShares();
+        uint256 expectedRecipientsPending = folio.feeRecipientsPendingFeeShares();
+        uint256 expectedSupply = folio.totalSupply();
+
+        vm.revertToState(snapshot);
+        vm.warp(finalBoundary);
+        folio.poke();
+
+        assertEq(folio.daoPendingFeeShares(), expectedDaoPending, "delayed poke changed DAO fees");
+        assertEq(
+            folio.feeRecipientsPendingFeeShares(),
+            expectedRecipientsPending,
+            "delayed poke changed recipient fees"
+        );
+        assertEq(folio.totalSupply(), expectedSupply, "delayed poke changed supply");
+        assertEq(folio.folioPendingFeeShares(), 0, "delayed poke did not settle mint self-fees");
     }
 
     /// @dev With folioFeeForSelf at 0%, behavior is unchanged from before
@@ -5475,15 +5607,35 @@ contract FolioTest is BaseTest {
 
         uint256 daoPendingAfterMint = folio.daoPendingFeeShares();
         uint256 recipientsPendingAfterMint = folio.feeRecipientsPendingFeeShares();
+        uint256 supplyAfterMint = folio.totalSupply();
 
         assertTrue(daoPendingAfterMint > 0, "dao should have pending mint fee shares");
+        assertTrue(folio.folioPendingFeeShares() > 0, "folio should have pending mint fee shares");
 
-        // fast forward 1 year for TVL fee
-        vm.warp(block.timestamp + YEAR_IN_SECONDS);
+        // advance to the first boundary for TVL fee settlement
+        vm.warp(((block.timestamp / ONE_DAY) + 1) * ONE_DAY);
         vm.roll(block.number + 1000000);
 
+        uint256 accountedUntil = (block.timestamp / ONE_DAY) * ONE_DAY;
+        (uint256 expectedDaoPending, uint256 expectedRecipientsPending, ) = FolioLib.computeFeeShares(
+            FolioLib.FeeSharesParams({
+                currentDaoPending: daoPendingAfterMint,
+                currentFeeRecipientsPending: recipientsPendingAfterMint,
+                tvlFee: folio.tvlFee(),
+                folioFeeForSelf: folio.folioFeeForSelf(),
+                supply: supplyAfterMint,
+                elapsed: accountedUntil - folio.lastPoke()
+            }),
+            daoFeeRegistry
+        );
+
         uint256 totalPending = folio.getPendingFeeShares();
-        assertTrue(totalPending > daoPendingAfterMint + recipientsPendingAfterMint, "tvl fees should add up");
+        assertEq(totalPending, expectedDaoPending + expectedRecipientsPending, "wrong combined pending fees");
+        assertEq(
+            folio.totalSupply(),
+            INITIAL_SUPPLY + folio.balanceOf(user1) + totalPending,
+            "wrong supply after combined settlement"
+        );
 
         // distribute
         folio.distributeFees();
@@ -5491,6 +5643,7 @@ contract FolioTest is BaseTest {
         // all pending should be distributed
         assertEq(folio.daoPendingFeeShares(), 0, "dao pending should be 0 after distribute");
         assertEq(folio.feeRecipientsPendingFeeShares(), 0, "fee recipients pending should be 0 after distribute");
+        assertEq(folio.folioPendingFeeShares(), 0, "folio pending should be 0 after settlement");
 
         // DAO and recipients should have non-zero balances
         assertTrue(folio.balanceOf(dao) > 0, "dao should have shares");


### PR DESCRIPTION
## Summary

- accrue mint self-fee shares as pending effective supply until the next daily fee boundary
- keep each mint exchange-rate neutral by increasing effective supply by the gross mint amount
- settle pending self-fees at the first boundary and exclude them from later TVL fee periods, even when poke is delayed
- document the new settlement behavior and lower optimizer runs to 50 for 455 bytes of Folio size headroom

## Accounting

For gross mint M, receiver shares + DAO pending shares + recipient pending shares + Folio pending self-fee shares = M. The Folio transfers backing for M, so the assets/share exchange rate is unchanged apart from existing per-token ceiling rounding. At the next daily boundary, the pending self-fee shares leave effective supply and the appreciation occurs once.

If multiple boundaries pass before poke, TVL fees are calculated in two intervals: through the first boundary with pending mint self-fees included, then after settlement with them excluded. This exactly matches poking at the first boundary and again later.

## Verification

- 221 core tests passed
- 4 extreme tests passed
- formatting and compilation passed
- lint completed with only pre-existing repository warnings
- delayed-poke equivalence regression passes exactly
- storage layout remains append-only at Folio slot 37
- Folio runtime size: 24,121 bytes, 455 bytes below EIP-170
- GPT-5.6 Sol high-reasoning review: approved, no blockers
- Grok 4.6 adversarial review: approved, no blockers

Fork tests could not run locally because fork RPC environment variables are unavailable; CI supplies them.