### PR TITLE
6.0.0 upgrade spell

### DIFF
--- a/contracts/spells/upgrades/UpgradeSpell_6_0_0.sol
+++ b/contracts/spells/upgrades/UpgradeSpell_6_0_0.sol
@@ -1,54 +1,69 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.28;
 
+import { IOptimisticSelectorRegistry } from "@reserve-protocol/reserve-governor/contracts/interfaces/IOptimisticSelectorRegistry.sol";
+import { IReserveOptimisticGovernor } from "@reserve-protocol/reserve-governor/contracts/interfaces/IReserveOptimisticGovernor.sol";
+
 import { Folio } from "@src/Folio.sol";
 import { FolioProxyAdmin } from "@folio/FolioProxy.sol";
-import { DEFAULT_ADMIN_ROLE } from "@utils/Constants.sol";
+import { DEFAULT_ADMIN_ROLE, MIN_AUCTION_LENGTH } from "@utils/Constants.sol";
 import { Versioned } from "@utils/Versioned.sol";
 
 bytes32 constant VERSION_5_0_0 = keccak256("5.0.0");
 bytes32 constant VERSION_6_0_0 = keccak256("6.0.0");
+bytes4 constant START_REBALANCE_5_0_0 = 0x207c8eed;
+bytes4 constant START_REBALANCE_6_0_0 = 0xc1e54b89;
+
+interface IFolio_5_0_0 {
+    function auctionLength() external view returns (uint256);
+}
+
+interface ISelectorRegistry_6_0_0 is IOptimisticSelectorRegistry {
+    function governor() external view returns (IReserveOptimisticGovernor);
+}
 
 /**
  * @title UpgradeSpell_6_0_0
- * @author tbrent
+ * @author akshatmittal, julianmrodri, pmckelvy1, tbrent
  * @notice Upgrades an idle Folio from 5.0.0 to 6.0.0.
  * @dev Transfer ProxyAdmin ownership to this contract and call cast() atomically from the Folio admin timelock.
- *      Optimistic selector-registry changes must be separate calls in the same standard governance proposal.
+ *      For optimistic governance, replace the startRebalance selector before cast() and pass the selector registry.
+ *      For legacy governance, pass address(0) as the selector registry.
  */
 contract UpgradeSpell_6_0_0 is Versioned {
-    error ActiveAuction();
-    error ActiveRebalance();
-    error InvalidVersion();
-    error NotProxyAdminOwner();
-    error StateChangeActive();
-    error UnauthorizedCaller();
-    error UnexpectedAdmins();
-    error UpgradeFailed();
+    error UpgradeSpell__Error(uint256 code);
 
-    function cast(Folio folio, FolioProxyAdmin proxyAdmin) external {
-        require(keccak256(bytes(folio.version())) == VERSION_5_0_0, InvalidVersion());
-        require(folio.hasRole(DEFAULT_ADMIN_ROLE, msg.sender), UnauthorizedCaller());
-        require(folio.getRoleMemberCount(DEFAULT_ADMIN_ROLE) == 1, UnexpectedAdmins());
-        require(folio.getRoleMember(DEFAULT_ADMIN_ROLE, 0) == msg.sender, UnexpectedAdmins());
-        require(proxyAdmin.owner() == address(this), NotProxyAdminOwner());
+    function cast(Folio folio, FolioProxyAdmin proxyAdmin, ISelectorRegistry_6_0_0 selectorRegistry) external {
+        require(keccak256(bytes(folio.version())) == VERSION_5_0_0, UpgradeSpell__Error(1));
+        require(folio.hasRole(DEFAULT_ADMIN_ROLE, msg.sender), UpgradeSpell__Error(2));
+        require(folio.getRoleMemberCount(DEFAULT_ADMIN_ROLE) == 1, UpgradeSpell__Error(3));
+        require(folio.getRoleMember(DEFAULT_ADMIN_ROLE, 0) == msg.sender, UpgradeSpell__Error(4));
+        require(proxyAdmin.owner() == address(this), UpgradeSpell__Error(5));
+
+        if (address(selectorRegistry) != address(0)) {
+            require(address(selectorRegistry.governor().timelock()) == msg.sender, UpgradeSpell__Error(6));
+            require(selectorRegistry.isAllowed(address(folio), START_REBALANCE_6_0_0), UpgradeSpell__Error(7));
+            require(!selectorRegistry.isAllowed(address(folio), START_REBALANCE_5_0_0), UpgradeSpell__Error(8));
+        }
+
+        require(IFolio_5_0_0(address(folio)).auctionLength() >= MIN_AUCTION_LENGTH, UpgradeSpell__Error(9));
 
         (bool syncStateChangeActive, bool asyncStateChangeActive) = folio.stateChangeActive();
-        require(!syncStateChangeActive && !asyncStateChangeActive, StateChangeActive());
+        require(!syncStateChangeActive && !asyncStateChangeActive, UpgradeSpell__Error(10));
 
         (, , , , Folio.RebalanceTimestamps memory timestamps, ) = folio.getRebalance();
-        require(timestamps.availableUntil <= block.timestamp, ActiveRebalance());
+        require(timestamps.availableUntil <= block.timestamp, UpgradeSpell__Error(11));
 
         uint256 nextAuctionId = folio.nextAuctionId();
         if (nextAuctionId != 0) {
             (, , uint256 endTime) = folio.auctions(nextAuctionId - 1);
-            require(endTime < block.timestamp, ActiveAuction());
+            require(endTime < block.timestamp, UpgradeSpell__Error(12));
         }
 
         proxyAdmin.upgradeToVersion(address(folio), VERSION_6_0_0, abi.encodeCall(Folio.poke, ()));
-        require(keccak256(bytes(folio.version())) == VERSION_6_0_0, UpgradeFailed());
+        require(keccak256(bytes(folio.version())) == VERSION_6_0_0, UpgradeSpell__Error(13));
 
         proxyAdmin.transferOwnership(msg.sender);
-        require(proxyAdmin.owner() == msg.sender, UpgradeFailed());
+        require(proxyAdmin.owner() == msg.sender, UpgradeSpell__Error(14));
     }
 }

--- a/contracts/spells/upgrades/UpgradeSpell_6_0_0.sol
+++ b/contracts/spells/upgrades/UpgradeSpell_6_0_0.sol
@@ -29,6 +29,12 @@ interface IOptimisticGovernor_6_0_0 is IReserveOptimisticGovernor {
     function selectorRegistry() external view returns (address);
 }
 
+interface IAccessControlEnumerable_6_0_0 {
+    function getRoleMemberCount(bytes32 role) external view returns (uint256);
+
+    function getRoleMember(bytes32 role, uint256 index) external view returns (address);
+}
+
 /**
  * @title UpgradeSpell_6_0_0
  * @author akshatmittal, julianmrodri, pmckelvy1, tbrent
@@ -47,7 +53,9 @@ contract UpgradeSpell_6_0_0 is Versioned {
         require(folio.getRoleMember(DEFAULT_ADMIN_ROLE, 0) == msg.sender, UpgradeSpell__Error(4));
         require(proxyAdmin.owner() == address(this), UpgradeSpell__Error(5));
 
-        if (address(selectorRegistry) != address(0)) {
+        if (address(selectorRegistry) == address(0)) {
+            _requireLegacyTimelock(msg.sender);
+        } else {
             address governor = selectorRegistry.governor();
             IOptimisticGovernor_6_0_0 optimisticGovernor = IOptimisticGovernor_6_0_0(governor);
 
@@ -77,5 +85,17 @@ contract UpgradeSpell_6_0_0 is Versioned {
 
         proxyAdmin.transferOwnership(msg.sender);
         require(proxyAdmin.owner() == msg.sender, UpgradeSpell__Error(16));
+    }
+
+    function _requireLegacyTimelock(address timelock) private view {
+        try IAccessControlEnumerable_6_0_0(timelock).getRoleMemberCount(PROPOSER_ROLE) returns (uint256 count) {
+            for (uint256 i; i < count; i++) {
+                address proposer = IAccessControlEnumerable_6_0_0(timelock).getRoleMember(PROPOSER_ROLE, i);
+
+                try IOptimisticGovernor_6_0_0(proposer).selectorRegistry() returns (address selectorRegistry) {
+                    require(selectorRegistry == address(0), UpgradeSpell__Error(6));
+                } catch {}
+            }
+        } catch {}
     }
 }

--- a/contracts/spells/upgrades/UpgradeSpell_6_0_0.sol
+++ b/contracts/spells/upgrades/UpgradeSpell_6_0_0.sol
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.28;
+
+import { Folio } from "@src/Folio.sol";
+import { FolioProxyAdmin } from "@folio/FolioProxy.sol";
+import { DEFAULT_ADMIN_ROLE } from "@utils/Constants.sol";
+import { Versioned } from "@utils/Versioned.sol";
+
+bytes32 constant VERSION_5_0_0 = keccak256("5.0.0");
+bytes32 constant VERSION_6_0_0 = keccak256("6.0.0");
+
+/**
+ * @title UpgradeSpell_6_0_0
+ * @author tbrent
+ * @notice Upgrades an idle Folio from 5.0.0 to 6.0.0.
+ * @dev Transfer ProxyAdmin ownership to this contract and call cast() atomically from the Folio admin timelock.
+ *      Optimistic selector-registry changes must be separate calls in the same standard governance proposal.
+ */
+contract UpgradeSpell_6_0_0 is Versioned {
+    error ActiveAuction();
+    error ActiveRebalance();
+    error InvalidVersion();
+    error NotProxyAdminOwner();
+    error StateChangeActive();
+    error UnauthorizedCaller();
+    error UnexpectedAdmins();
+    error UpgradeFailed();
+
+    function cast(Folio folio, FolioProxyAdmin proxyAdmin) external {
+        require(keccak256(bytes(folio.version())) == VERSION_5_0_0, InvalidVersion());
+        require(folio.hasRole(DEFAULT_ADMIN_ROLE, msg.sender), UnauthorizedCaller());
+        require(folio.getRoleMemberCount(DEFAULT_ADMIN_ROLE) == 1, UnexpectedAdmins());
+        require(folio.getRoleMember(DEFAULT_ADMIN_ROLE, 0) == msg.sender, UnexpectedAdmins());
+        require(proxyAdmin.owner() == address(this), NotProxyAdminOwner());
+
+        (bool syncStateChangeActive, bool asyncStateChangeActive) = folio.stateChangeActive();
+        require(!syncStateChangeActive && !asyncStateChangeActive, StateChangeActive());
+
+        (, , , , Folio.RebalanceTimestamps memory timestamps, ) = folio.getRebalance();
+        require(timestamps.availableUntil <= block.timestamp, ActiveRebalance());
+
+        uint256 nextAuctionId = folio.nextAuctionId();
+        if (nextAuctionId != 0) {
+            (, , uint256 endTime) = folio.auctions(nextAuctionId - 1);
+            require(endTime < block.timestamp, ActiveAuction());
+        }
+
+        proxyAdmin.upgradeToVersion(address(folio), VERSION_6_0_0, abi.encodeCall(Folio.poke, ()));
+        require(keccak256(bytes(folio.version())) == VERSION_6_0_0, UpgradeFailed());
+
+        proxyAdmin.transferOwnership(msg.sender);
+        require(proxyAdmin.owner() == msg.sender, UpgradeFailed());
+    }
+}

--- a/contracts/spells/upgrades/UpgradeSpell_6_0_0.sol
+++ b/contracts/spells/upgrades/UpgradeSpell_6_0_0.sol
@@ -1,8 +1,11 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.28;
 
+import { IAccessControl } from "@openzeppelin/contracts/access/IAccessControl.sol";
+
 import { IOptimisticSelectorRegistry } from "@reserve-protocol/reserve-governor/contracts/interfaces/IOptimisticSelectorRegistry.sol";
 import { IReserveOptimisticGovernor } from "@reserve-protocol/reserve-governor/contracts/interfaces/IReserveOptimisticGovernor.sol";
+import { PROPOSER_ROLE } from "@reserve-protocol/reserve-governor/contracts/utils/Constants.sol";
 
 import { Folio } from "@src/Folio.sol";
 import { FolioProxyAdmin } from "@folio/FolioProxy.sol";
@@ -19,7 +22,11 @@ interface IFolio_5_0_0 {
 }
 
 interface ISelectorRegistry_6_0_0 is IOptimisticSelectorRegistry {
-    function governor() external view returns (IReserveOptimisticGovernor);
+    function governor() external view returns (address);
+}
+
+interface IOptimisticGovernor_6_0_0 is IReserveOptimisticGovernor {
+    function selectorRegistry() external view returns (address);
 }
 
 /**
@@ -41,29 +48,34 @@ contract UpgradeSpell_6_0_0 is Versioned {
         require(proxyAdmin.owner() == address(this), UpgradeSpell__Error(5));
 
         if (address(selectorRegistry) != address(0)) {
-            require(address(selectorRegistry.governor().timelock()) == msg.sender, UpgradeSpell__Error(6));
-            require(selectorRegistry.isAllowed(address(folio), START_REBALANCE_6_0_0), UpgradeSpell__Error(7));
-            require(!selectorRegistry.isAllowed(address(folio), START_REBALANCE_5_0_0), UpgradeSpell__Error(8));
+            address governor = selectorRegistry.governor();
+            IOptimisticGovernor_6_0_0 optimisticGovernor = IOptimisticGovernor_6_0_0(governor);
+
+            require(optimisticGovernor.timelock() == msg.sender, UpgradeSpell__Error(6));
+            require(IAccessControl(msg.sender).hasRole(PROPOSER_ROLE, governor), UpgradeSpell__Error(7));
+            require(optimisticGovernor.selectorRegistry() == address(selectorRegistry), UpgradeSpell__Error(8));
+            require(selectorRegistry.isAllowed(address(folio), START_REBALANCE_6_0_0), UpgradeSpell__Error(9));
+            require(!selectorRegistry.isAllowed(address(folio), START_REBALANCE_5_0_0), UpgradeSpell__Error(10));
         }
 
-        require(IFolio_5_0_0(address(folio)).auctionLength() >= MIN_AUCTION_LENGTH, UpgradeSpell__Error(9));
+        require(IFolio_5_0_0(address(folio)).auctionLength() >= MIN_AUCTION_LENGTH, UpgradeSpell__Error(11));
 
         (bool syncStateChangeActive, bool asyncStateChangeActive) = folio.stateChangeActive();
-        require(!syncStateChangeActive && !asyncStateChangeActive, UpgradeSpell__Error(10));
+        require(!syncStateChangeActive && !asyncStateChangeActive, UpgradeSpell__Error(12));
 
         (, , , , Folio.RebalanceTimestamps memory timestamps, ) = folio.getRebalance();
-        require(timestamps.availableUntil <= block.timestamp, UpgradeSpell__Error(11));
+        require(timestamps.availableUntil <= block.timestamp, UpgradeSpell__Error(13));
 
         uint256 nextAuctionId = folio.nextAuctionId();
         if (nextAuctionId != 0) {
             (, , uint256 endTime) = folio.auctions(nextAuctionId - 1);
-            require(endTime < block.timestamp, UpgradeSpell__Error(12));
+            require(endTime < block.timestamp, UpgradeSpell__Error(14));
         }
 
         proxyAdmin.upgradeToVersion(address(folio), VERSION_6_0_0, abi.encodeCall(Folio.poke, ()));
-        require(keccak256(bytes(folio.version())) == VERSION_6_0_0, UpgradeSpell__Error(13));
+        require(keccak256(bytes(folio.version())) == VERSION_6_0_0, UpgradeSpell__Error(15));
 
         proxyAdmin.transferOwnership(msg.sender);
-        require(proxyAdmin.owner() == msg.sender, UpgradeSpell__Error(14));
+        require(proxyAdmin.owner() == msg.sender, UpgradeSpell__Error(16));
     }
 }

--- a/contracts/spells/upgrades/UpgradeSpell_6_0_0.sol
+++ b/contracts/spells/upgrades/UpgradeSpell_6_0_0.sol
@@ -14,6 +14,7 @@ import { Versioned } from "@utils/Versioned.sol";
 
 bytes32 constant VERSION_5_0_0 = keccak256("5.0.0");
 bytes32 constant VERSION_6_0_0 = keccak256("6.0.0");
+bytes4 constant START_REBALANCE_5_0_0 = 0x207c8eed;
 bytes4 constant START_REBALANCE_6_0_0 = 0xc1e54b89;
 
 interface IFolio_5_0_0 {
@@ -32,9 +33,9 @@ interface IOptimisticGovernor_6_0_0 is IReserveOptimisticGovernor {
  * @title UpgradeSpell_6_0_0
  * @author akshatmittal, julianmrodri, pmckelvy1, tbrent
  * @notice Upgrades an idle Folio from 5.0.0 to 6.0.0.
- * @dev Transfer ProxyAdmin ownership to this contract and call cast() atomically from the Folio admin timelock.
- *      For optimistic governance, register the new startRebalance selector before cast() and pass the selector registry.
- *      For legacy governance, pass address(0) as the selector registry.
+ * @dev The Folio admin timelock should atomically register the 6.0.0 startRebalance selector, unregister the 5.0.0
+ *      selector, transfer ProxyAdmin ownership to this contract, then call cast(). For legacy governance, pass
+ *      address(0) as the selector registry and atomically transfer ProxyAdmin ownership before calling cast().
  */
 contract UpgradeSpell_6_0_0 is Versioned {
     error UpgradeSpell__Error(uint256 code);
@@ -54,26 +55,27 @@ contract UpgradeSpell_6_0_0 is Versioned {
             require(IAccessControl(msg.sender).hasRole(PROPOSER_ROLE, governor), UpgradeSpell__Error(7));
             require(optimisticGovernor.selectorRegistry() == address(selectorRegistry), UpgradeSpell__Error(8));
             require(selectorRegistry.isAllowed(address(folio), START_REBALANCE_6_0_0), UpgradeSpell__Error(9));
+            require(!selectorRegistry.isAllowed(address(folio), START_REBALANCE_5_0_0), UpgradeSpell__Error(10));
         }
 
-        require(IFolio_5_0_0(address(folio)).auctionLength() >= MIN_AUCTION_LENGTH, UpgradeSpell__Error(10));
+        require(IFolio_5_0_0(address(folio)).auctionLength() >= MIN_AUCTION_LENGTH, UpgradeSpell__Error(11));
 
         (bool syncStateChangeActive, bool asyncStateChangeActive) = folio.stateChangeActive();
-        require(!syncStateChangeActive && !asyncStateChangeActive, UpgradeSpell__Error(11));
+        require(!syncStateChangeActive && !asyncStateChangeActive, UpgradeSpell__Error(12));
 
         (, , , , Folio.RebalanceTimestamps memory timestamps, ) = folio.getRebalance();
-        require(timestamps.availableUntil <= block.timestamp, UpgradeSpell__Error(12));
+        require(timestamps.availableUntil <= block.timestamp, UpgradeSpell__Error(13));
 
         uint256 nextAuctionId = folio.nextAuctionId();
         if (nextAuctionId != 0) {
             (, , uint256 endTime) = folio.auctions(nextAuctionId - 1);
-            require(endTime < block.timestamp, UpgradeSpell__Error(13));
+            require(endTime < block.timestamp, UpgradeSpell__Error(14));
         }
 
         proxyAdmin.upgradeToVersion(address(folio), VERSION_6_0_0, abi.encodeCall(Folio.poke, ()));
-        require(keccak256(bytes(folio.version())) == VERSION_6_0_0, UpgradeSpell__Error(14));
+        require(keccak256(bytes(folio.version())) == VERSION_6_0_0, UpgradeSpell__Error(15));
 
         proxyAdmin.transferOwnership(msg.sender);
-        require(proxyAdmin.owner() == msg.sender, UpgradeSpell__Error(15));
+        require(proxyAdmin.owner() == msg.sender, UpgradeSpell__Error(16));
     }
 }

--- a/contracts/spells/upgrades/UpgradeSpell_6_0_0.sol
+++ b/contracts/spells/upgrades/UpgradeSpell_6_0_0.sol
@@ -14,7 +14,6 @@ import { Versioned } from "@utils/Versioned.sol";
 
 bytes32 constant VERSION_5_0_0 = keccak256("5.0.0");
 bytes32 constant VERSION_6_0_0 = keccak256("6.0.0");
-bytes4 constant START_REBALANCE_5_0_0 = 0x207c8eed;
 bytes4 constant START_REBALANCE_6_0_0 = 0xc1e54b89;
 
 interface IFolio_5_0_0 {
@@ -34,7 +33,7 @@ interface IOptimisticGovernor_6_0_0 is IReserveOptimisticGovernor {
  * @author akshatmittal, julianmrodri, pmckelvy1, tbrent
  * @notice Upgrades an idle Folio from 5.0.0 to 6.0.0.
  * @dev Transfer ProxyAdmin ownership to this contract and call cast() atomically from the Folio admin timelock.
- *      For optimistic governance, replace the startRebalance selector before cast() and pass the selector registry.
+ *      For optimistic governance, register the new startRebalance selector before cast() and pass the selector registry.
  *      For legacy governance, pass address(0) as the selector registry.
  */
 contract UpgradeSpell_6_0_0 is Versioned {
@@ -55,27 +54,26 @@ contract UpgradeSpell_6_0_0 is Versioned {
             require(IAccessControl(msg.sender).hasRole(PROPOSER_ROLE, governor), UpgradeSpell__Error(7));
             require(optimisticGovernor.selectorRegistry() == address(selectorRegistry), UpgradeSpell__Error(8));
             require(selectorRegistry.isAllowed(address(folio), START_REBALANCE_6_0_0), UpgradeSpell__Error(9));
-            require(!selectorRegistry.isAllowed(address(folio), START_REBALANCE_5_0_0), UpgradeSpell__Error(10));
         }
 
-        require(IFolio_5_0_0(address(folio)).auctionLength() >= MIN_AUCTION_LENGTH, UpgradeSpell__Error(11));
+        require(IFolio_5_0_0(address(folio)).auctionLength() >= MIN_AUCTION_LENGTH, UpgradeSpell__Error(10));
 
         (bool syncStateChangeActive, bool asyncStateChangeActive) = folio.stateChangeActive();
-        require(!syncStateChangeActive && !asyncStateChangeActive, UpgradeSpell__Error(12));
+        require(!syncStateChangeActive && !asyncStateChangeActive, UpgradeSpell__Error(11));
 
         (, , , , Folio.RebalanceTimestamps memory timestamps, ) = folio.getRebalance();
-        require(timestamps.availableUntil <= block.timestamp, UpgradeSpell__Error(13));
+        require(timestamps.availableUntil <= block.timestamp, UpgradeSpell__Error(12));
 
         uint256 nextAuctionId = folio.nextAuctionId();
         if (nextAuctionId != 0) {
             (, , uint256 endTime) = folio.auctions(nextAuctionId - 1);
-            require(endTime < block.timestamp, UpgradeSpell__Error(14));
+            require(endTime < block.timestamp, UpgradeSpell__Error(13));
         }
 
         proxyAdmin.upgradeToVersion(address(folio), VERSION_6_0_0, abi.encodeCall(Folio.poke, ()));
-        require(keccak256(bytes(folio.version())) == VERSION_6_0_0, UpgradeSpell__Error(15));
+        require(keccak256(bytes(folio.version())) == VERSION_6_0_0, UpgradeSpell__Error(14));
 
         proxyAdmin.transferOwnership(msg.sender);
-        require(proxyAdmin.owner() == msg.sender, UpgradeSpell__Error(16));
+        require(proxyAdmin.owner() == msg.sender, UpgradeSpell__Error(15));
     }
 }

--- a/test/spells/UpgradeSpell_6_0_0/GenericUpgradeSpell_6_0_0.t.sol
+++ b/test/spells/UpgradeSpell_6_0_0/GenericUpgradeSpell_6_0_0.t.sol
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.28;
+
+import { Test } from "forge-std/Test.sol";
+
+import { IOptimisticSelectorRegistry } from "@reserve-protocol/reserve-governor/contracts/interfaces/IOptimisticSelectorRegistry.sol";
+
+import { Folio } from "@src/Folio.sol";
+import { FolioDeployer } from "@deployer/FolioDeployer.sol";
+import { FolioProxyAdmin } from "@folio/FolioProxy.sol";
+import { FolioVersionRegistry } from "@folio/FolioVersionRegistry.sol";
+import { DEFAULT_ADMIN_ROLE } from "@utils/Constants.sol";
+import { UpgradeSpell_6_0_0, VERSION_6_0_0, START_REBALANCE_5_0_0, START_REBALANCE_6_0_0, ISelectorRegistry_6_0_0 } from "../../../contracts/spells/upgrades/UpgradeSpell_6_0_0.sol";
+
+interface ISelectorRegistryAdminFork_6_0_0 is ISelectorRegistry_6_0_0 {
+    function registerSelectors(IOptimisticSelectorRegistry.SelectorData[] calldata selectorData) external;
+
+    function unregisterSelectors(IOptimisticSelectorRegistry.SelectorData[] calldata selectorData) external;
+}
+
+abstract contract GenericUpgradeSpell_6_0_0ForkTest is Test {
+    bytes32 private constant ADMIN_SLOT = 0xb53127684a568b3173ae13b9f8a6016e243e63b6e8ee1178d6a717850b5d6103;
+    address private constant ROLE_REGISTRY_OWNER = 0xe8259842e71f4E44F2F68D6bfbC15EDA56E63064;
+
+    struct Config {
+        Folio folio;
+        ISelectorRegistryAdminFork_6_0_0 selectorRegistry;
+    }
+
+    UpgradeSpell_6_0_0 internal spell;
+
+    function _setUpSpell(address versionRegistryAddress) internal {
+        FolioVersionRegistry versionRegistry = FolioVersionRegistry(versionRegistryAddress);
+        if (address(versionRegistry.deployments(VERSION_6_0_0)) == address(0)) {
+            FolioDeployer folioDeployer = new FolioDeployer(address(0), versionRegistryAddress, address(0), address(0));
+            vm.prank(ROLE_REGISTRY_OWNER);
+            versionRegistry.registerVersion(folioDeployer);
+        }
+
+        spell = new UpgradeSpell_6_0_0();
+    }
+
+    function _runUpgrade(Config memory config) internal {
+        Folio folio = config.folio;
+        FolioProxyAdmin proxyAdmin = FolioProxyAdmin(address(uint160(uint256(vm.load(address(folio), ADMIN_SLOT)))));
+        address timelock = proxyAdmin.owner();
+
+        assertEq(folio.version(), "5.0.0");
+
+        uint256 totalSupply = folio.totalSupply();
+        string memory name = folio.name();
+        string memory symbol = folio.symbol();
+
+        vm.startPrank(timelock);
+        if (address(config.selectorRegistry) != address(0)) {
+            assertTrue(config.selectorRegistry.isAllowed(address(folio), START_REBALANCE_5_0_0));
+
+            IOptimisticSelectorRegistry.SelectorData[]
+                memory selectorData = new IOptimisticSelectorRegistry.SelectorData[](1);
+            bytes4[] memory selectors = new bytes4[](1);
+            selectorData[0] = IOptimisticSelectorRegistry.SelectorData({
+                target: address(folio),
+                selectors: selectors
+            });
+
+            selectors[0] = START_REBALANCE_6_0_0;
+            config.selectorRegistry.registerSelectors(selectorData);
+            selectors[0] = START_REBALANCE_5_0_0;
+            config.selectorRegistry.unregisterSelectors(selectorData);
+        }
+
+        proxyAdmin.transferOwnership(address(spell));
+        spell.cast(folio, proxyAdmin, config.selectorRegistry);
+        vm.stopPrank();
+
+        assertEq(folio.version(), "6.0.0", symbol);
+        assertEq(folio.lastFolioFeePoke(), block.timestamp, symbol);
+        assertEq(folio.totalSupply(), totalSupply, symbol);
+        assertEq(folio.name(), name, symbol);
+        assertEq(folio.symbol(), symbol, symbol);
+        assertEq(folio.getRoleMemberCount(DEFAULT_ADMIN_ROLE), 1, symbol);
+        assertEq(folio.getRoleMember(DEFAULT_ADMIN_ROLE, 0), timelock, symbol);
+        assertEq(proxyAdmin.owner(), timelock, symbol);
+
+        if (address(config.selectorRegistry) != address(0)) {
+            assertFalse(config.selectorRegistry.isAllowed(address(folio), START_REBALANCE_5_0_0), symbol);
+            assertTrue(config.selectorRegistry.isAllowed(address(folio), START_REBALANCE_6_0_0), symbol);
+        }
+    }
+}

--- a/test/spells/UpgradeSpell_6_0_0/UpgradeSpellBase_6_0_0Fork.t.sol
+++ b/test/spells/UpgradeSpell_6_0_0/UpgradeSpellBase_6_0_0Fork.t.sol
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.28;
+
+import { Folio } from "@src/Folio.sol";
+import { ISelectorRegistryAdminFork_6_0_0, GenericUpgradeSpell_6_0_0ForkTest } from "./GenericUpgradeSpell_6_0_0.t.sol";
+
+contract UpgradeSpellBase_6_0_0ForkTest is GenericUpgradeSpell_6_0_0ForkTest {
+    uint256 private constant FORK_BLOCK = 50_451_750;
+    address private constant VERSION_REGISTRY = 0xA665b273997F70b647B66fa7Ed021287544849dB;
+
+    Config[] private configs;
+
+    function setUp() public {
+        vm.createSelectFork(vm.envOr("FORK_RPC_BASE", string("base")), FORK_BLOCK);
+        _setUpSpell(VERSION_REGISTRY);
+
+        // Active Index DTF snapshot: api.reserve.org/discover/dtfs, 2026-08-25
+        configs.push(
+            Config(Folio(0x23418De10d422AD71C9D5713a2B8991a9c586443), ISelectorRegistryAdminFork_6_0_0(address(0)))
+        ); // BGCI
+        configs.push(
+            Config(Folio(0x44551CA46Fa5592bb572E20043f7C3D54c85cAD7), ISelectorRegistryAdminFork_6_0_0(address(0)))
+        ); // CLX
+        configs.push(
+            Config(Folio(0x4dA9A0f397dB1397902070f93a4D6ddBC0E0E6e8), ISelectorRegistryAdminFork_6_0_0(address(0)))
+        ); // LCAP
+        configs.push(
+            Config(
+                Folio(0xCEF8Db49E456f872E288E1C042F916E9ceD7c781),
+                ISelectorRegistryAdminFork_6_0_0(0xA5977360e7bd8EF6dB8992F1Dc68B5415995Fa75)
+            )
+        ); // MAG7
+        configs.push(
+            Config(Folio(0xe8b46b116D3BdFA787CE9CF3f5aCC78dc7cA380E), ISelectorRegistryAdminFork_6_0_0(address(0)))
+        ); // MVTT10F
+        configs.push(
+            Config(Folio(0xe00CFa595841fb331105b93C19827797C925E3E4), ISelectorRegistryAdminFork_6_0_0(address(0)))
+        ); // VLONE
+    }
+
+    function test_upgradeActive5_0_0Folios() public {
+        for (uint256 i; i < configs.length; i++) {
+            _runUpgrade(configs[i]);
+        }
+    }
+
+    function test_activeFoliosNotYetEligibleFor6_0_0() public view {
+        assertEq(Folio(0xeBcda5b80f62DD4DD2A96357b42BB6Facbf30267).version(), "4.0.0"); // ABX
+        assertEq(Folio(0xb8753941196692E322846cfEE9C14C97AC81928A).version(), "2.0.0"); // BDTF
+    }
+}

--- a/test/spells/UpgradeSpell_6_0_0/UpgradeSpellBsc_6_0_0Fork.t.sol
+++ b/test/spells/UpgradeSpell_6_0_0/UpgradeSpellBsc_6_0_0Fork.t.sol
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.28;
+
+import { Folio } from "@src/Folio.sol";
+import { ISelectorRegistryAdminFork_6_0_0, GenericUpgradeSpell_6_0_0ForkTest } from "./GenericUpgradeSpell_6_0_0.t.sol";
+
+contract UpgradeSpellBsc_6_0_0ForkTest is GenericUpgradeSpell_6_0_0ForkTest {
+    address private constant VERSION_REGISTRY = 0x79A4E963378AE34fC6c796a24c764322fC6c9390;
+
+    Config[] private configs;
+
+    function setUp() public {
+        // The configured public BSC endpoint is not archival, so use latest state.
+        vm.createSelectFork(vm.envOr("FORK_RPC_BSC", string("bsc")));
+        _setUpSpell(VERSION_REGISTRY);
+
+        // Active Index DTF snapshot: api.reserve.org/discover/dtfs, 2026-08-25
+        configs.push(
+            Config(
+                Folio(0xD7cE7a841310982AcD976D1a6fe7BB6063c5689D),
+                ISelectorRegistryAdminFork_6_0_0(0xeFF38e77A193e17352206B6F416441a4001687A1)
+            )
+        ); // BUILDOUT
+        configs.push(
+            Config(Folio(0x2f8A339B5889FfaC4c5A956787cdA593b3c36867), ISelectorRegistryAdminFork_6_0_0(address(0)))
+        ); // CMC20
+        configs.push(
+            Config(
+                Folio(0xf571Fe3F0d74521Bc7310B111Faea931C748f27B),
+                ISelectorRegistryAdminFork_6_0_0(0x68B65996528E294FC95BeB5E278A39d3c0eF975C)
+            )
+        ); // NEOCLOUD
+        configs.push(
+            Config(
+                Folio(0xa0Fe4e0aEca5479705ce996615B2EACB6b6a10Fb),
+                ISelectorRegistryAdminFork_6_0_0(0x285CfA670345eb13c05516252590e81b2eaE43e3)
+            )
+        ); // PHOTON
+        configs.push(
+            Config(
+                Folio(0x290bCc0Fd5096cC3261AE2021841c7BC67Cb0f51),
+                ISelectorRegistryAdminFork_6_0_0(0xE8d03514542f87A4Dc6511ABA98707A864159322)
+            )
+        ); // POWER
+        configs.push(
+            Config(
+                Folio(0x75617e7653f86f074Cc30b9Fd4eBf52bA9b62247),
+                ISelectorRegistryAdminFork_6_0_0(0x3bB11415946aCbB664CA136aF3EA3e7beA31Be67)
+            )
+        ); // ROBOTS
+    }
+
+    function test_upgradeActive5_0_0Folios() public {
+        for (uint256 i; i < configs.length; i++) {
+            _runUpgrade(configs[i]);
+        }
+    }
+}

--- a/test/spells/UpgradeSpell_6_0_0/UpgradeSpellEthereum_6_0_0Fork.t.sol
+++ b/test/spells/UpgradeSpell_6_0_0/UpgradeSpellEthereum_6_0_0Fork.t.sol
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.28;
+
+import { Folio } from "@src/Folio.sol";
+import { ISelectorRegistryAdminFork_6_0_0, GenericUpgradeSpell_6_0_0ForkTest } from "./GenericUpgradeSpell_6_0_0.t.sol";
+
+contract UpgradeSpellEthereum_6_0_0ForkTest is GenericUpgradeSpell_6_0_0ForkTest {
+    uint256 private constant FORK_BLOCK = 25_834_864;
+    address private constant VERSION_REGISTRY = 0xA665b273997F70b647B66fa7Ed021287544849dB;
+
+    Config[] private configs;
+
+    function setUp() public {
+        vm.createSelectFork(vm.envOr("FORK_RPC_MAINNET", string("mainnet")), FORK_BLOCK);
+        _setUpSpell(VERSION_REGISTRY);
+
+        // Active Index DTF snapshot: api.reserve.org/discover/dtfs, 2026-08-25
+        configs.push(
+            Config(Folio(0x188D12Eb13a5Eadd0867074ce8354B1AD6f4790b), ISelectorRegistryAdminFork_6_0_0(address(0)))
+        ); // DFX
+        configs.push(
+            Config(Folio(0xe4a10951f962e6cB93Cb843a4ef05d2F99DB1F94), ISelectorRegistryAdminFork_6_0_0(address(0)))
+        ); // ixEdel
+    }
+
+    function test_upgradeActive5_0_0Folios() public {
+        for (uint256 i; i < configs.length; i++) {
+            _runUpgrade(configs[i]);
+        }
+    }
+
+    function test_activeFoliosNotYetEligibleFor6_0_0() public view {
+        assertEq(Folio(0x9a1741E151233a82Cf69209A2F1bC7442B1fB29C).version(), "4.0.0"); // DGI
+        assertEq(Folio(0x323c03c48660fE31186fa82c289b0766d331Ce21).version(), "4.0.0"); // OPEN
+    }
+}

--- a/test/spells/UpgradeSpell_6_0_0/UpgradeSpell_6_0_0Fork.t.sol
+++ b/test/spells/UpgradeSpell_6_0_0/UpgradeSpell_6_0_0Fork.t.sol
@@ -10,7 +10,7 @@ import { FolioDeployer } from "@deployer/FolioDeployer.sol";
 import { FolioProxyAdmin } from "@folio/FolioProxy.sol";
 import { FolioVersionRegistry } from "@folio/FolioVersionRegistry.sol";
 import { DEFAULT_ADMIN_ROLE } from "@utils/Constants.sol";
-import { UpgradeSpell_6_0_0, VERSION_6_0_0, START_REBALANCE_6_0_0, ISelectorRegistry_6_0_0 } from "../../../contracts/spells/upgrades/UpgradeSpell_6_0_0.sol";
+import { UpgradeSpell_6_0_0, VERSION_6_0_0, START_REBALANCE_5_0_0, START_REBALANCE_6_0_0, ISelectorRegistry_6_0_0 } from "../../../contracts/spells/upgrades/UpgradeSpell_6_0_0.sol";
 
 interface ISelectorRegistryAdmin_6_0_0 is ISelectorRegistry_6_0_0 {
     function registerSelectors(IOptimisticSelectorRegistry.SelectorData[] calldata selectorData) external;
@@ -98,6 +98,8 @@ contract UpgradeSpell_6_0_0ForkTest is Test {
         vm.startPrank(TIMELOCK);
         selectors[0] = START_REBALANCE_6_0_0;
         selectorRegistry.registerSelectors(selectorData);
+        selectors[0] = START_REBALANCE_5_0_0;
+        selectorRegistry.unregisterSelectors(selectorData);
         proxyAdmin.transferOwnership(address(spell));
         vm.stopPrank();
     }
@@ -118,7 +120,7 @@ contract UpgradeSpell_6_0_0ForkTest is Test {
         assertEq(folio.getRoleMemberCount(DEFAULT_ADMIN_ROLE), 1);
         assertEq(folio.getRoleMember(DEFAULT_ADMIN_ROLE, 0), TIMELOCK);
         assertEq(proxyAdmin.owner(), TIMELOCK);
-        assertTrue(selectorRegistry.isAllowed(address(folio), 0x207c8eed));
+        assertFalse(selectorRegistry.isAllowed(address(folio), START_REBALANCE_5_0_0));
         assertTrue(selectorRegistry.isAllowed(address(folio), START_REBALANCE_6_0_0));
     }
 
@@ -138,6 +140,22 @@ contract UpgradeSpell_6_0_0ForkTest is Test {
         vm.stopPrank();
     }
 
+    function test_castRevertsUntilOldSelectorIsUnregistered() public {
+        IOptimisticSelectorRegistry.SelectorData[] memory selectorData = new IOptimisticSelectorRegistry.SelectorData[](
+            1
+        );
+        bytes4[] memory selectors = new bytes4[](1);
+        selectors[0] = START_REBALANCE_5_0_0;
+        selectorData[0] = IOptimisticSelectorRegistry.SelectorData({ target: address(folio), selectors: selectors });
+
+        vm.startPrank(TIMELOCK);
+        selectorRegistry.registerSelectors(selectorData);
+
+        vm.expectRevert(abi.encodeWithSelector(UpgradeSpell_6_0_0.UpgradeSpell__Error.selector, 10));
+        spell.cast(folio, proxyAdmin, selectorRegistry);
+        vm.stopPrank();
+    }
+
     function test_castRejectsFakeSelectorRegistry() public {
         ISelectorRegistry_6_0_0 fakeSelectorRegistry = ISelectorRegistry_6_0_0(
             address(new FakeSelectorRegistry(TIMELOCK))
@@ -151,7 +169,7 @@ contract UpgradeSpell_6_0_0ForkTest is Test {
     function test_castRevertsForShortAuctionLength() public {
         vm.store(address(folio), bytes32(uint256(15)), bytes32(uint256(119))); // auctionLength
 
-        vm.expectRevert(abi.encodeWithSelector(UpgradeSpell_6_0_0.UpgradeSpell__Error.selector, 10));
+        vm.expectRevert(abi.encodeWithSelector(UpgradeSpell_6_0_0.UpgradeSpell__Error.selector, 11));
         vm.prank(TIMELOCK);
         spell.cast(folio, proxyAdmin, selectorRegistry);
     }
@@ -163,7 +181,7 @@ contract UpgradeSpell_6_0_0ForkTest is Test {
             bytes32(uint256(uint160(address(new ActiveTrustedFill()))))
         );
 
-        vm.expectRevert(abi.encodeWithSelector(UpgradeSpell_6_0_0.UpgradeSpell__Error.selector, 11));
+        vm.expectRevert(abi.encodeWithSelector(UpgradeSpell_6_0_0.UpgradeSpell__Error.selector, 12));
         vm.prank(TIMELOCK);
         spell.cast(folio, proxyAdmin, selectorRegistry);
     }
@@ -171,7 +189,7 @@ contract UpgradeSpell_6_0_0ForkTest is Test {
     function test_castRevertsForActiveRebalance() public {
         vm.store(address(folio), bytes32(uint256(28)), bytes32(block.timestamp + 1)); // rebalance.availableUntil
 
-        vm.expectRevert(abi.encodeWithSelector(UpgradeSpell_6_0_0.UpgradeSpell__Error.selector, 12));
+        vm.expectRevert(abi.encodeWithSelector(UpgradeSpell_6_0_0.UpgradeSpell__Error.selector, 13));
         vm.prank(TIMELOCK);
         spell.cast(folio, proxyAdmin, selectorRegistry);
     }
@@ -182,7 +200,7 @@ contract UpgradeSpell_6_0_0ForkTest is Test {
         bytes32 auctionSlot = keccak256(abi.encode(uint256(0), uint256(30)));
         vm.store(address(folio), bytes32(uint256(auctionSlot) + 3), bytes32(block.timestamp)); // auction.endTime
 
-        vm.expectRevert(abi.encodeWithSelector(UpgradeSpell_6_0_0.UpgradeSpell__Error.selector, 13));
+        vm.expectRevert(abi.encodeWithSelector(UpgradeSpell_6_0_0.UpgradeSpell__Error.selector, 14));
         vm.prank(TIMELOCK);
         spell.cast(folio, proxyAdmin, selectorRegistry);
     }

--- a/test/spells/UpgradeSpell_6_0_0/UpgradeSpell_6_0_0Fork.t.sol
+++ b/test/spells/UpgradeSpell_6_0_0/UpgradeSpell_6_0_0Fork.t.sol
@@ -156,6 +156,12 @@ contract UpgradeSpell_6_0_0ForkTest is Test {
         vm.stopPrank();
     }
 
+    function test_castRejectsMissingSelectorRegistryForOptimisticGovernance() public {
+        vm.expectRevert(abi.encodeWithSelector(UpgradeSpell_6_0_0.UpgradeSpell__Error.selector, 6));
+        vm.prank(TIMELOCK);
+        spell.cast(folio, proxyAdmin, ISelectorRegistry_6_0_0(address(0)));
+    }
+
     function test_castRejectsFakeSelectorRegistry() public {
         ISelectorRegistry_6_0_0 fakeSelectorRegistry = ISelectorRegistry_6_0_0(
             address(new FakeSelectorRegistry(TIMELOCK))

--- a/test/spells/UpgradeSpell_6_0_0/UpgradeSpell_6_0_0Fork.t.sol
+++ b/test/spells/UpgradeSpell_6_0_0/UpgradeSpell_6_0_0Fork.t.sol
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.28;
+
+import { Test } from "forge-std/Test.sol";
+
+import { Folio } from "@src/Folio.sol";
+import { FolioDeployer } from "@deployer/FolioDeployer.sol";
+import { FolioProxyAdmin } from "@folio/FolioProxy.sol";
+import { FolioVersionRegistry } from "@folio/FolioVersionRegistry.sol";
+import { DEFAULT_ADMIN_ROLE } from "@utils/Constants.sol";
+import { UpgradeSpell_6_0_0, VERSION_6_0_0 } from "../../../contracts/spells/upgrades/UpgradeSpell_6_0_0.sol";
+
+contract ActiveTrustedFill {
+    function swapActive() external pure returns (bool) {
+        return true;
+    }
+}
+
+contract UpgradeSpell_6_0_0ForkTest is Test {
+    uint256 private constant FORK_BLOCK = 25_282_010;
+
+    address private constant FOLIO = 0x5039ECE83DC4E0621eBEc391128339Bd859a84d0;
+    address private constant PROXY_ADMIN = 0x5f272F35654d72eA7e87C35BdE585a2d2d75BfEC;
+    address private constant TIMELOCK = 0x5b7310B7f17048AafdD34767ef447764B0072c8c;
+
+    address private constant DAO_FEE_REGISTRY = 0x0262E3e15cCFD2221b35D05909222f1f5FCdcd80;
+    address private constant VERSION_REGISTRY = 0xA665b273997F70b647B66fa7Ed021287544849dB;
+    address private constant TRUSTED_FILLER_REGISTRY = 0x279ccF56441fC74f1aAC39E7faC165Dec5A88B3A;
+    address private constant ROLE_REGISTRY_OWNER = 0xe8259842e71f4E44F2F68D6bfbC15EDA56E63064;
+
+    Folio private folio;
+    FolioProxyAdmin private proxyAdmin;
+    UpgradeSpell_6_0_0 private spell;
+
+    function setUp() public {
+        vm.createSelectFork(vm.envOr("FORK_RPC_MAINNET", string("mainnet")), FORK_BLOCK);
+
+        folio = Folio(FOLIO);
+        proxyAdmin = FolioProxyAdmin(PROXY_ADMIN);
+        spell = new UpgradeSpell_6_0_0();
+
+        FolioVersionRegistry versionRegistry = FolioVersionRegistry(VERSION_REGISTRY);
+        if (address(versionRegistry.deployments(VERSION_6_0_0)) == address(0)) {
+            FolioDeployer folioDeployer = new FolioDeployer(
+                DAO_FEE_REGISTRY,
+                VERSION_REGISTRY,
+                TRUSTED_FILLER_REGISTRY,
+                address(0)
+            );
+            vm.prank(ROLE_REGISTRY_OWNER);
+            versionRegistry.registerVersion(folioDeployer);
+        }
+
+        vm.prank(TIMELOCK);
+        proxyAdmin.transferOwnership(address(spell));
+    }
+
+    function test_cast() public {
+        uint256 totalSupply = folio.totalSupply();
+        string memory name = folio.name();
+        string memory symbol = folio.symbol();
+
+        vm.prank(TIMELOCK);
+        spell.cast(folio, proxyAdmin);
+
+        assertEq(folio.version(), "6.0.0");
+        assertEq(folio.lastFolioFeePoke(), block.timestamp);
+        assertEq(folio.totalSupply(), totalSupply);
+        assertEq(folio.name(), name);
+        assertEq(folio.symbol(), symbol);
+        assertEq(folio.getRoleMemberCount(DEFAULT_ADMIN_ROLE), 1);
+        assertEq(folio.getRoleMember(DEFAULT_ADMIN_ROLE, 0), TIMELOCK);
+        assertEq(proxyAdmin.owner(), TIMELOCK);
+    }
+
+    function test_castRevertsForActiveStateChange() public {
+        vm.store(
+            address(folio),
+            bytes32(uint256(19)), // activeTrustedFill
+            bytes32(uint256(uint160(address(new ActiveTrustedFill()))))
+        );
+
+        vm.expectRevert(UpgradeSpell_6_0_0.StateChangeActive.selector);
+        vm.prank(TIMELOCK);
+        spell.cast(folio, proxyAdmin);
+    }
+
+    function test_castRevertsForActiveRebalance() public {
+        vm.store(address(folio), bytes32(uint256(28)), bytes32(block.timestamp + 1)); // rebalance.availableUntil
+
+        vm.expectRevert(UpgradeSpell_6_0_0.ActiveRebalance.selector);
+        vm.prank(TIMELOCK);
+        spell.cast(folio, proxyAdmin);
+    }
+
+    function test_castRevertsForActiveAuction() public {
+        vm.store(address(folio), bytes32(uint256(31)), bytes32(uint256(1))); // nextAuctionId
+
+        bytes32 auctionSlot = keccak256(abi.encode(uint256(0), uint256(30)));
+        vm.store(address(folio), bytes32(uint256(auctionSlot) + 3), bytes32(block.timestamp)); // auction.endTime
+
+        vm.expectRevert(UpgradeSpell_6_0_0.ActiveAuction.selector);
+        vm.prank(TIMELOCK);
+        spell.cast(folio, proxyAdmin);
+    }
+}

--- a/test/spells/UpgradeSpell_6_0_0/UpgradeSpell_6_0_0Fork.t.sol
+++ b/test/spells/UpgradeSpell_6_0_0/UpgradeSpell_6_0_0Fork.t.sol
@@ -10,7 +10,7 @@ import { FolioDeployer } from "@deployer/FolioDeployer.sol";
 import { FolioProxyAdmin } from "@folio/FolioProxy.sol";
 import { FolioVersionRegistry } from "@folio/FolioVersionRegistry.sol";
 import { DEFAULT_ADMIN_ROLE } from "@utils/Constants.sol";
-import { UpgradeSpell_6_0_0, VERSION_6_0_0, START_REBALANCE_5_0_0, START_REBALANCE_6_0_0, ISelectorRegistry_6_0_0 } from "../../../contracts/spells/upgrades/UpgradeSpell_6_0_0.sol";
+import { UpgradeSpell_6_0_0, VERSION_6_0_0, START_REBALANCE_6_0_0, ISelectorRegistry_6_0_0 } from "../../../contracts/spells/upgrades/UpgradeSpell_6_0_0.sol";
 
 interface ISelectorRegistryAdmin_6_0_0 is ISelectorRegistry_6_0_0 {
     function registerSelectors(IOptimisticSelectorRegistry.SelectorData[] calldata selectorData) external;
@@ -98,8 +98,6 @@ contract UpgradeSpell_6_0_0ForkTest is Test {
         vm.startPrank(TIMELOCK);
         selectors[0] = START_REBALANCE_6_0_0;
         selectorRegistry.registerSelectors(selectorData);
-        selectors[0] = START_REBALANCE_5_0_0;
-        selectorRegistry.unregisterSelectors(selectorData);
         proxyAdmin.transferOwnership(address(spell));
         vm.stopPrank();
     }
@@ -120,9 +118,11 @@ contract UpgradeSpell_6_0_0ForkTest is Test {
         assertEq(folio.getRoleMemberCount(DEFAULT_ADMIN_ROLE), 1);
         assertEq(folio.getRoleMember(DEFAULT_ADMIN_ROLE, 0), TIMELOCK);
         assertEq(proxyAdmin.owner(), TIMELOCK);
+        assertTrue(selectorRegistry.isAllowed(address(folio), 0x207c8eed));
+        assertTrue(selectorRegistry.isAllowed(address(folio), START_REBALANCE_6_0_0));
     }
 
-    function test_castRevertsUntilSelectorsAreUpdated() public {
+    function test_castRevertsUntilNewSelectorIsRegistered() public {
         IOptimisticSelectorRegistry.SelectorData[] memory selectorData = new IOptimisticSelectorRegistry.SelectorData[](
             1
         );
@@ -130,8 +130,6 @@ contract UpgradeSpell_6_0_0ForkTest is Test {
         selectorData[0] = IOptimisticSelectorRegistry.SelectorData({ target: address(folio), selectors: selectors });
 
         vm.startPrank(TIMELOCK);
-        selectors[0] = START_REBALANCE_5_0_0;
-        selectorRegistry.registerSelectors(selectorData);
         selectors[0] = START_REBALANCE_6_0_0;
         selectorRegistry.unregisterSelectors(selectorData);
 
@@ -153,7 +151,7 @@ contract UpgradeSpell_6_0_0ForkTest is Test {
     function test_castRevertsForShortAuctionLength() public {
         vm.store(address(folio), bytes32(uint256(15)), bytes32(uint256(119))); // auctionLength
 
-        vm.expectRevert(abi.encodeWithSelector(UpgradeSpell_6_0_0.UpgradeSpell__Error.selector, 11));
+        vm.expectRevert(abi.encodeWithSelector(UpgradeSpell_6_0_0.UpgradeSpell__Error.selector, 10));
         vm.prank(TIMELOCK);
         spell.cast(folio, proxyAdmin, selectorRegistry);
     }
@@ -165,7 +163,7 @@ contract UpgradeSpell_6_0_0ForkTest is Test {
             bytes32(uint256(uint160(address(new ActiveTrustedFill()))))
         );
 
-        vm.expectRevert(abi.encodeWithSelector(UpgradeSpell_6_0_0.UpgradeSpell__Error.selector, 12));
+        vm.expectRevert(abi.encodeWithSelector(UpgradeSpell_6_0_0.UpgradeSpell__Error.selector, 11));
         vm.prank(TIMELOCK);
         spell.cast(folio, proxyAdmin, selectorRegistry);
     }
@@ -173,7 +171,7 @@ contract UpgradeSpell_6_0_0ForkTest is Test {
     function test_castRevertsForActiveRebalance() public {
         vm.store(address(folio), bytes32(uint256(28)), bytes32(block.timestamp + 1)); // rebalance.availableUntil
 
-        vm.expectRevert(abi.encodeWithSelector(UpgradeSpell_6_0_0.UpgradeSpell__Error.selector, 13));
+        vm.expectRevert(abi.encodeWithSelector(UpgradeSpell_6_0_0.UpgradeSpell__Error.selector, 12));
         vm.prank(TIMELOCK);
         spell.cast(folio, proxyAdmin, selectorRegistry);
     }
@@ -184,7 +182,7 @@ contract UpgradeSpell_6_0_0ForkTest is Test {
         bytes32 auctionSlot = keccak256(abi.encode(uint256(0), uint256(30)));
         vm.store(address(folio), bytes32(uint256(auctionSlot) + 3), bytes32(block.timestamp)); // auction.endTime
 
-        vm.expectRevert(abi.encodeWithSelector(UpgradeSpell_6_0_0.UpgradeSpell__Error.selector, 14));
+        vm.expectRevert(abi.encodeWithSelector(UpgradeSpell_6_0_0.UpgradeSpell__Error.selector, 13));
         vm.prank(TIMELOCK);
         spell.cast(folio, proxyAdmin, selectorRegistry);
     }

--- a/test/spells/UpgradeSpell_6_0_0/UpgradeSpell_6_0_0Fork.t.sol
+++ b/test/spells/UpgradeSpell_6_0_0/UpgradeSpell_6_0_0Fork.t.sol
@@ -3,12 +3,20 @@ pragma solidity 0.8.28;
 
 import { Test } from "forge-std/Test.sol";
 
+import { IOptimisticSelectorRegistry } from "@reserve-protocol/reserve-governor/contracts/interfaces/IOptimisticSelectorRegistry.sol";
+
 import { Folio } from "@src/Folio.sol";
 import { FolioDeployer } from "@deployer/FolioDeployer.sol";
 import { FolioProxyAdmin } from "@folio/FolioProxy.sol";
 import { FolioVersionRegistry } from "@folio/FolioVersionRegistry.sol";
 import { DEFAULT_ADMIN_ROLE } from "@utils/Constants.sol";
-import { UpgradeSpell_6_0_0, VERSION_6_0_0 } from "../../../contracts/spells/upgrades/UpgradeSpell_6_0_0.sol";
+import { UpgradeSpell_6_0_0, VERSION_6_0_0, START_REBALANCE_5_0_0, START_REBALANCE_6_0_0, ISelectorRegistry_6_0_0 } from "../../../contracts/spells/upgrades/UpgradeSpell_6_0_0.sol";
+
+interface ISelectorRegistryAdmin_6_0_0 is ISelectorRegistry_6_0_0 {
+    function registerSelectors(IOptimisticSelectorRegistry.SelectorData[] calldata selectorData) external;
+
+    function unregisterSelectors(IOptimisticSelectorRegistry.SelectorData[] calldata selectorData) external;
+}
 
 contract ActiveTrustedFill {
     function swapActive() external pure returns (bool) {
@@ -22,6 +30,7 @@ contract UpgradeSpell_6_0_0ForkTest is Test {
     address private constant FOLIO = 0x5039ECE83DC4E0621eBEc391128339Bd859a84d0;
     address private constant PROXY_ADMIN = 0x5f272F35654d72eA7e87C35BdE585a2d2d75BfEC;
     address private constant TIMELOCK = 0x5b7310B7f17048AafdD34767ef447764B0072c8c;
+    address private constant SELECTOR_REGISTRY = 0xA1C763301462411795cB5E320FA48e0622CEAa90;
 
     address private constant DAO_FEE_REGISTRY = 0x0262E3e15cCFD2221b35D05909222f1f5FCdcd80;
     address private constant VERSION_REGISTRY = 0xA665b273997F70b647B66fa7Ed021287544849dB;
@@ -30,6 +39,7 @@ contract UpgradeSpell_6_0_0ForkTest is Test {
 
     Folio private folio;
     FolioProxyAdmin private proxyAdmin;
+    ISelectorRegistryAdmin_6_0_0 private selectorRegistry;
     UpgradeSpell_6_0_0 private spell;
 
     function setUp() public {
@@ -37,6 +47,7 @@ contract UpgradeSpell_6_0_0ForkTest is Test {
 
         folio = Folio(FOLIO);
         proxyAdmin = FolioProxyAdmin(PROXY_ADMIN);
+        selectorRegistry = ISelectorRegistryAdmin_6_0_0(SELECTOR_REGISTRY);
         spell = new UpgradeSpell_6_0_0();
 
         FolioVersionRegistry versionRegistry = FolioVersionRegistry(VERSION_REGISTRY);
@@ -51,8 +62,19 @@ contract UpgradeSpell_6_0_0ForkTest is Test {
             versionRegistry.registerVersion(folioDeployer);
         }
 
-        vm.prank(TIMELOCK);
+        IOptimisticSelectorRegistry.SelectorData[] memory selectorData = new IOptimisticSelectorRegistry.SelectorData[](
+            1
+        );
+        bytes4[] memory selectors = new bytes4[](1);
+        selectorData[0] = IOptimisticSelectorRegistry.SelectorData({ target: address(folio), selectors: selectors });
+
+        vm.startPrank(TIMELOCK);
+        selectors[0] = START_REBALANCE_6_0_0;
+        selectorRegistry.registerSelectors(selectorData);
+        selectors[0] = START_REBALANCE_5_0_0;
+        selectorRegistry.unregisterSelectors(selectorData);
         proxyAdmin.transferOwnership(address(spell));
+        vm.stopPrank();
     }
 
     function test_cast() public {
@@ -61,7 +83,7 @@ contract UpgradeSpell_6_0_0ForkTest is Test {
         string memory symbol = folio.symbol();
 
         vm.prank(TIMELOCK);
-        spell.cast(folio, proxyAdmin);
+        spell.cast(folio, proxyAdmin, selectorRegistry);
 
         assertEq(folio.version(), "6.0.0");
         assertEq(folio.lastFolioFeePoke(), block.timestamp);
@@ -73,6 +95,32 @@ contract UpgradeSpell_6_0_0ForkTest is Test {
         assertEq(proxyAdmin.owner(), TIMELOCK);
     }
 
+    function test_castRevertsUntilSelectorsAreUpdated() public {
+        IOptimisticSelectorRegistry.SelectorData[] memory selectorData = new IOptimisticSelectorRegistry.SelectorData[](
+            1
+        );
+        bytes4[] memory selectors = new bytes4[](1);
+        selectorData[0] = IOptimisticSelectorRegistry.SelectorData({ target: address(folio), selectors: selectors });
+
+        vm.startPrank(TIMELOCK);
+        selectors[0] = START_REBALANCE_5_0_0;
+        selectorRegistry.registerSelectors(selectorData);
+        selectors[0] = START_REBALANCE_6_0_0;
+        selectorRegistry.unregisterSelectors(selectorData);
+
+        vm.expectRevert(abi.encodeWithSelector(UpgradeSpell_6_0_0.UpgradeSpell__Error.selector, 7));
+        spell.cast(folio, proxyAdmin, selectorRegistry);
+        vm.stopPrank();
+    }
+
+    function test_castRevertsForShortAuctionLength() public {
+        vm.store(address(folio), bytes32(uint256(15)), bytes32(uint256(119))); // auctionLength
+
+        vm.expectRevert(abi.encodeWithSelector(UpgradeSpell_6_0_0.UpgradeSpell__Error.selector, 9));
+        vm.prank(TIMELOCK);
+        spell.cast(folio, proxyAdmin, selectorRegistry);
+    }
+
     function test_castRevertsForActiveStateChange() public {
         vm.store(
             address(folio),
@@ -80,17 +128,17 @@ contract UpgradeSpell_6_0_0ForkTest is Test {
             bytes32(uint256(uint160(address(new ActiveTrustedFill()))))
         );
 
-        vm.expectRevert(UpgradeSpell_6_0_0.StateChangeActive.selector);
+        vm.expectRevert(abi.encodeWithSelector(UpgradeSpell_6_0_0.UpgradeSpell__Error.selector, 10));
         vm.prank(TIMELOCK);
-        spell.cast(folio, proxyAdmin);
+        spell.cast(folio, proxyAdmin, selectorRegistry);
     }
 
     function test_castRevertsForActiveRebalance() public {
         vm.store(address(folio), bytes32(uint256(28)), bytes32(block.timestamp + 1)); // rebalance.availableUntil
 
-        vm.expectRevert(UpgradeSpell_6_0_0.ActiveRebalance.selector);
+        vm.expectRevert(abi.encodeWithSelector(UpgradeSpell_6_0_0.UpgradeSpell__Error.selector, 11));
         vm.prank(TIMELOCK);
-        spell.cast(folio, proxyAdmin);
+        spell.cast(folio, proxyAdmin, selectorRegistry);
     }
 
     function test_castRevertsForActiveAuction() public {
@@ -99,8 +147,8 @@ contract UpgradeSpell_6_0_0ForkTest is Test {
         bytes32 auctionSlot = keccak256(abi.encode(uint256(0), uint256(30)));
         vm.store(address(folio), bytes32(uint256(auctionSlot) + 3), bytes32(block.timestamp)); // auction.endTime
 
-        vm.expectRevert(UpgradeSpell_6_0_0.ActiveAuction.selector);
+        vm.expectRevert(abi.encodeWithSelector(UpgradeSpell_6_0_0.UpgradeSpell__Error.selector, 12));
         vm.prank(TIMELOCK);
-        spell.cast(folio, proxyAdmin);
+        spell.cast(folio, proxyAdmin, selectorRegistry);
     }
 }

--- a/test/spells/UpgradeSpell_6_0_0/UpgradeSpell_6_0_0Fork.t.sol
+++ b/test/spells/UpgradeSpell_6_0_0/UpgradeSpell_6_0_0Fork.t.sol
@@ -18,6 +18,33 @@ interface ISelectorRegistryAdmin_6_0_0 is ISelectorRegistry_6_0_0 {
     function unregisterSelectors(IOptimisticSelectorRegistry.SelectorData[] calldata selectorData) external;
 }
 
+contract FakeOptimisticGovernor {
+    address public immutable timelock;
+    address public selectorRegistry;
+
+    constructor(address _timelock) {
+        timelock = _timelock;
+    }
+
+    function setSelectorRegistry(address _selectorRegistry) external {
+        selectorRegistry = _selectorRegistry;
+    }
+}
+
+contract FakeSelectorRegistry {
+    address public immutable governor;
+
+    constructor(address timelock) {
+        FakeOptimisticGovernor fakeGovernor = new FakeOptimisticGovernor(timelock);
+        governor = address(fakeGovernor);
+        fakeGovernor.setSelectorRegistry(address(this));
+    }
+
+    function isAllowed(address, bytes4 selector) external pure returns (bool) {
+        return selector == START_REBALANCE_6_0_0;
+    }
+}
+
 contract ActiveTrustedFill {
     function swapActive() external pure returns (bool) {
         return true;
@@ -108,15 +135,25 @@ contract UpgradeSpell_6_0_0ForkTest is Test {
         selectors[0] = START_REBALANCE_6_0_0;
         selectorRegistry.unregisterSelectors(selectorData);
 
-        vm.expectRevert(abi.encodeWithSelector(UpgradeSpell_6_0_0.UpgradeSpell__Error.selector, 7));
+        vm.expectRevert(abi.encodeWithSelector(UpgradeSpell_6_0_0.UpgradeSpell__Error.selector, 9));
         spell.cast(folio, proxyAdmin, selectorRegistry);
         vm.stopPrank();
+    }
+
+    function test_castRejectsFakeSelectorRegistry() public {
+        ISelectorRegistry_6_0_0 fakeSelectorRegistry = ISelectorRegistry_6_0_0(
+            address(new FakeSelectorRegistry(TIMELOCK))
+        );
+
+        vm.expectRevert(abi.encodeWithSelector(UpgradeSpell_6_0_0.UpgradeSpell__Error.selector, 7));
+        vm.prank(TIMELOCK);
+        spell.cast(folio, proxyAdmin, fakeSelectorRegistry);
     }
 
     function test_castRevertsForShortAuctionLength() public {
         vm.store(address(folio), bytes32(uint256(15)), bytes32(uint256(119))); // auctionLength
 
-        vm.expectRevert(abi.encodeWithSelector(UpgradeSpell_6_0_0.UpgradeSpell__Error.selector, 9));
+        vm.expectRevert(abi.encodeWithSelector(UpgradeSpell_6_0_0.UpgradeSpell__Error.selector, 11));
         vm.prank(TIMELOCK);
         spell.cast(folio, proxyAdmin, selectorRegistry);
     }
@@ -128,7 +165,7 @@ contract UpgradeSpell_6_0_0ForkTest is Test {
             bytes32(uint256(uint160(address(new ActiveTrustedFill()))))
         );
 
-        vm.expectRevert(abi.encodeWithSelector(UpgradeSpell_6_0_0.UpgradeSpell__Error.selector, 10));
+        vm.expectRevert(abi.encodeWithSelector(UpgradeSpell_6_0_0.UpgradeSpell__Error.selector, 12));
         vm.prank(TIMELOCK);
         spell.cast(folio, proxyAdmin, selectorRegistry);
     }
@@ -136,7 +173,7 @@ contract UpgradeSpell_6_0_0ForkTest is Test {
     function test_castRevertsForActiveRebalance() public {
         vm.store(address(folio), bytes32(uint256(28)), bytes32(block.timestamp + 1)); // rebalance.availableUntil
 
-        vm.expectRevert(abi.encodeWithSelector(UpgradeSpell_6_0_0.UpgradeSpell__Error.selector, 11));
+        vm.expectRevert(abi.encodeWithSelector(UpgradeSpell_6_0_0.UpgradeSpell__Error.selector, 13));
         vm.prank(TIMELOCK);
         spell.cast(folio, proxyAdmin, selectorRegistry);
     }
@@ -147,7 +184,7 @@ contract UpgradeSpell_6_0_0ForkTest is Test {
         bytes32 auctionSlot = keccak256(abi.encode(uint256(0), uint256(30)));
         vm.store(address(folio), bytes32(uint256(auctionSlot) + 3), bytes32(block.timestamp)); // auction.endTime
 
-        vm.expectRevert(abi.encodeWithSelector(UpgradeSpell_6_0_0.UpgradeSpell__Error.selector, 12));
+        vm.expectRevert(abi.encodeWithSelector(UpgradeSpell_6_0_0.UpgradeSpell__Error.selector, 14));
         vm.prank(TIMELOCK);
         spell.cast(folio, proxyAdmin, selectorRegistry);
     }


### PR DESCRIPTION
## Summary

Deployment-only 5.0.0 → 6.0.0 Folio upgrade spell, following the PR #157 pattern.

The spell:
- uses one numbered custom error type
- requires `stateChangeActive()` to return `(false, false)`
- requires no active rebalance or auction
- requires the inherited v5 auction length to satisfy the new v6 minimum of 120 seconds
- requires exactly one Folio admin, matching the caller
- rejects a zero selector registry when the caller is an optimistic timelock
- for optimistic governance, authenticates the registry through a timelock-authorized governor and the governor’s canonical registry pointer, then verifies the v6 `startRebalance` selector is registered and the v5 selector is unregistered
- upgrades atomically with `poke()` as upgrade calldata
- returns ProxyAdmin ownership to the caller timelock

The standard optimistic-governance proposal should execute atomically:
1. register the v6 `startRebalance` selector
2. unregister the v5 `startRebalance` selector
3. `proxyAdmin.transferOwnership(spell)`
4. `spell.cast(folio, proxyAdmin, selectorRegistry)`

Legacy governance passes `address(0)` for `selectorRegistry` and needs only steps 3–4. This adds one spell argument; the Folio has no reliable onchain link to distinguish legacy from optimistic governance automatically.

## Repository handling

**Do not merge this PR into `main`.** The spell and fork test intentionally live on this persistent upgrade branch. `docs/SPELLS.md` on `main` links to the exact commit in #213.

## Verification

- `forge build`
- `forge test --match-contract UpgradeSpell_6_0_0ForkTest -vv`
- Fork upgrades for every active 5.0.0 Index DTF returned by `api.reserve.org/discover/dtfs` on Ethereum, Base, and BSC
- Explicit inventory coverage for active DGI, OPEN, ABX, and BDTF, which are not yet eligible because they remain below 5.0.0
- Revert coverage for missing/fake registries, missing v6 and lingering v5 selectors, auction length below 120 seconds, active state change, active rebalance, and active auction


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Upgrade execution now validates selector registries and governance compatibility.
  - Rebalance selectors must be correctly registered, with legacy selectors removed.
  - Legacy auction settings must meet the minimum required duration.

- **Bug Fixes**
  - Added safeguards against invalid registries, incompatible governance settings, active operations, and unauthorized upgrades.
  - Upgrade failures now return standardized error codes for easier diagnosis.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->