### PR TITLE
Document 6.0.0 upgrade spell

### DIFF
--- a/docs/SPELLS.md
+++ b/docs/SPELLS.md
@@ -1,14 +1,14 @@
 # Archived Spells
 
 Spells and spell tests were removed from the repository.
-Use the links below to view the exact files at commits `62a9942fb91b6af46740a40dc085b0cbe9ad4ee0` and `8b623c1660b9e75729b641136eb58deb8972b846`.
+Use the links below to view the exact files at commits `62a9942fb91b6af46740a40dc085b0cbe9ad4ee0` and `d2c97f76e5b0874fed6bdec7c617efa2cdcdc9be`.
 
 ## Spell Contracts
 
 - [GovernanceSpell_31_03_2025](https://github.com/reserve-protocol/reserve-folio/blob/62a9942fb91b6af46740a40dc085b0cbe9ad4ee0/contracts/spells/31-03-2025/GovernanceSpell_31_03_2025.sol)
 - [UpgradeSpell_4_0_0](https://github.com/reserve-protocol/reserve-folio/blob/62a9942fb91b6af46740a40dc085b0cbe9ad4ee0/contracts/spells/upgrades/UpgradeSpell_4_0_0.sol)
 - [UpgradeSpell_5_0_0](https://github.com/reserve-protocol/reserve-folio/blob/62a9942fb91b6af46740a40dc085b0cbe9ad4ee0/contracts/spells/upgrades/UpgradeSpell_5_0_0.sol)
-- [UpgradeSpell_6_0_0](https://github.com/reserve-protocol/reserve-index-dtf/blob/8b623c1660b9e75729b641136eb58deb8972b846/contracts/spells/upgrades/UpgradeSpell_6_0_0.sol)
+- [UpgradeSpell_6_0_0](https://github.com/reserve-protocol/reserve-index-dtf/blob/d2c97f76e5b0874fed6bdec7c617efa2cdcdc9be/contracts/spells/upgrades/UpgradeSpell_6_0_0.sol)
 
 ## Spell Tests
 

--- a/docs/SPELLS.md
+++ b/docs/SPELLS.md
@@ -1,21 +1,14 @@
 # Archived Spells
 
-Upgrade spells are maintained outside `main`. Use the commit links below to review the exact deployed source and tests.
+Spells and spell tests were removed from the repository.
+Use the links below to view the exact files at commits `62a9942fb91b6af46740a40dc085b0cbe9ad4ee0` and `8b623c1660b9e75729b641136eb58deb8972b846`.
 
-## 6.0.0 Upgrade Spell
-
-The 5.0.0 → 6.0.0 spell is maintained on the dedicated `upgrade-spell-6.0.0` branch and reviewed in [PR #212](https://github.com/reserve-protocol/reserve-index-dtf/pull/212).
-
-- [UpgradeSpell_6_0_0](https://github.com/reserve-protocol/reserve-index-dtf/blob/e76e0a047241d463f188aed3edadbf864474334e/contracts/spells/upgrades/UpgradeSpell_6_0_0.sol)
-- [UpgradeSpell_6_0_0 fork tests](https://github.com/reserve-protocol/reserve-index-dtf/blob/e76e0a047241d463f188aed3edadbf864474334e/test/spells/UpgradeSpell_6_0_0/UpgradeSpell_6_0_0Fork.t.sol)
-
-## Earlier Spell Contracts
-
-The earlier spell files and tests are preserved at commit `62a9942fb91b6af46740a40dc085b0cbe9ad4ee0`.
+## Spell Contracts
 
 - [GovernanceSpell_31_03_2025](https://github.com/reserve-protocol/reserve-folio/blob/62a9942fb91b6af46740a40dc085b0cbe9ad4ee0/contracts/spells/31-03-2025/GovernanceSpell_31_03_2025.sol)
 - [UpgradeSpell_4_0_0](https://github.com/reserve-protocol/reserve-folio/blob/62a9942fb91b6af46740a40dc085b0cbe9ad4ee0/contracts/spells/upgrades/UpgradeSpell_4_0_0.sol)
 - [UpgradeSpell_5_0_0](https://github.com/reserve-protocol/reserve-folio/blob/62a9942fb91b6af46740a40dc085b0cbe9ad4ee0/contracts/spells/upgrades/UpgradeSpell_5_0_0.sol)
+- [UpgradeSpell_6_0_0](https://github.com/reserve-protocol/reserve-index-dtf/blob/8b623c1660b9e75729b641136eb58deb8972b846/contracts/spells/upgrades/UpgradeSpell_6_0_0.sol)
 
 ## Spell Tests
 

--- a/docs/SPELLS.md
+++ b/docs/SPELLS.md
@@ -1,14 +1,14 @@
 # Archived Spells
 
 Spells and spell tests were removed from the repository.
-Use the links below to view the exact files at commits `62a9942fb91b6af46740a40dc085b0cbe9ad4ee0` and `d2c97f76e5b0874fed6bdec7c617efa2cdcdc9be`.
+Use the links below to view the exact files at commits `62a9942fb91b6af46740a40dc085b0cbe9ad4ee0` and `6edbb9de82d74a7c2d6593c40adb98c1d95a2c06`.
 
 ## Spell Contracts
 
 - [GovernanceSpell_31_03_2025](https://github.com/reserve-protocol/reserve-folio/blob/62a9942fb91b6af46740a40dc085b0cbe9ad4ee0/contracts/spells/31-03-2025/GovernanceSpell_31_03_2025.sol)
 - [UpgradeSpell_4_0_0](https://github.com/reserve-protocol/reserve-folio/blob/62a9942fb91b6af46740a40dc085b0cbe9ad4ee0/contracts/spells/upgrades/UpgradeSpell_4_0_0.sol)
 - [UpgradeSpell_5_0_0](https://github.com/reserve-protocol/reserve-folio/blob/62a9942fb91b6af46740a40dc085b0cbe9ad4ee0/contracts/spells/upgrades/UpgradeSpell_5_0_0.sol)
-- [UpgradeSpell_6_0_0](https://github.com/reserve-protocol/reserve-index-dtf/blob/d2c97f76e5b0874fed6bdec7c617efa2cdcdc9be/contracts/spells/upgrades/UpgradeSpell_6_0_0.sol)
+- [UpgradeSpell_6_0_0](https://github.com/reserve-protocol/reserve-index-dtf/blob/6edbb9de82d74a7c2d6593c40adb98c1d95a2c06/contracts/spells/upgrades/UpgradeSpell_6_0_0.sol)
 
 ## Spell Tests
 

--- a/docs/SPELLS.md
+++ b/docs/SPELLS.md
@@ -1,14 +1,14 @@
 # Archived Spells
 
 Spells and spell tests were removed from the repository.
-Use the links below to view the exact files at commits `62a9942fb91b6af46740a40dc085b0cbe9ad4ee0` and `6edbb9de82d74a7c2d6593c40adb98c1d95a2c06`.
+Use the links below to view the exact files at commits `62a9942fb91b6af46740a40dc085b0cbe9ad4ee0` and `2b48c11715d3bb8e8b571d6230ba65e82d1a0db7`.
 
 ## Spell Contracts
 
 - [GovernanceSpell_31_03_2025](https://github.com/reserve-protocol/reserve-folio/blob/62a9942fb91b6af46740a40dc085b0cbe9ad4ee0/contracts/spells/31-03-2025/GovernanceSpell_31_03_2025.sol)
 - [UpgradeSpell_4_0_0](https://github.com/reserve-protocol/reserve-folio/blob/62a9942fb91b6af46740a40dc085b0cbe9ad4ee0/contracts/spells/upgrades/UpgradeSpell_4_0_0.sol)
 - [UpgradeSpell_5_0_0](https://github.com/reserve-protocol/reserve-folio/blob/62a9942fb91b6af46740a40dc085b0cbe9ad4ee0/contracts/spells/upgrades/UpgradeSpell_5_0_0.sol)
-- [UpgradeSpell_6_0_0](https://github.com/reserve-protocol/reserve-index-dtf/blob/6edbb9de82d74a7c2d6593c40adb98c1d95a2c06/contracts/spells/upgrades/UpgradeSpell_6_0_0.sol)
+- [UpgradeSpell_6_0_0](https://github.com/reserve-protocol/reserve-index-dtf/blob/2b48c11715d3bb8e8b571d6230ba65e82d1a0db7/contracts/spells/upgrades/UpgradeSpell_6_0_0.sol)
 
 ## Spell Tests
 

--- a/docs/SPELLS.md
+++ b/docs/SPELLS.md
@@ -1,14 +1,14 @@
 # Archived Spells
 
 Spells and spell tests were removed from the repository.
-Use the links below to view the exact files at commits `62a9942fb91b6af46740a40dc085b0cbe9ad4ee0` and `2b48c11715d3bb8e8b571d6230ba65e82d1a0db7`.
+Use the links below to view the exact files at commits `62a9942fb91b6af46740a40dc085b0cbe9ad4ee0` and `33c315690a71c826b5bcd01b69110f478ccd865d`.
 
 ## Spell Contracts
 
 - [GovernanceSpell_31_03_2025](https://github.com/reserve-protocol/reserve-folio/blob/62a9942fb91b6af46740a40dc085b0cbe9ad4ee0/contracts/spells/31-03-2025/GovernanceSpell_31_03_2025.sol)
 - [UpgradeSpell_4_0_0](https://github.com/reserve-protocol/reserve-folio/blob/62a9942fb91b6af46740a40dc085b0cbe9ad4ee0/contracts/spells/upgrades/UpgradeSpell_4_0_0.sol)
 - [UpgradeSpell_5_0_0](https://github.com/reserve-protocol/reserve-folio/blob/62a9942fb91b6af46740a40dc085b0cbe9ad4ee0/contracts/spells/upgrades/UpgradeSpell_5_0_0.sol)
-- [UpgradeSpell_6_0_0](https://github.com/reserve-protocol/reserve-index-dtf/blob/2b48c11715d3bb8e8b571d6230ba65e82d1a0db7/contracts/spells/upgrades/UpgradeSpell_6_0_0.sol)
+- [UpgradeSpell_6_0_0](https://github.com/reserve-protocol/reserve-index-dtf/blob/33c315690a71c826b5bcd01b69110f478ccd865d/contracts/spells/upgrades/UpgradeSpell_6_0_0.sol)
 
 ## Spell Tests
 

--- a/docs/SPELLS.md
+++ b/docs/SPELLS.md
@@ -1,9 +1,17 @@
 # Archived Spells
 
-Spells and spell tests were removed from the repository.
-Use the links below to view the exact files at commit `62a9942fb91b6af46740a40dc085b0cbe9ad4ee0`.
+Upgrade spells are maintained outside `main`. Use the commit links below to review the exact deployed source and tests.
 
-## Spell Contracts
+## 6.0.0 Upgrade Spell
+
+The 5.0.0 → 6.0.0 spell is maintained on the dedicated `upgrade-spell-6.0.0` branch and reviewed in [PR #212](https://github.com/reserve-protocol/reserve-index-dtf/pull/212).
+
+- [UpgradeSpell_6_0_0](https://github.com/reserve-protocol/reserve-index-dtf/blob/e76e0a047241d463f188aed3edadbf864474334e/contracts/spells/upgrades/UpgradeSpell_6_0_0.sol)
+- [UpgradeSpell_6_0_0 fork tests](https://github.com/reserve-protocol/reserve-index-dtf/blob/e76e0a047241d463f188aed3edadbf864474334e/test/spells/UpgradeSpell_6_0_0/UpgradeSpell_6_0_0Fork.t.sol)
+
+## Earlier Spell Contracts
+
+The earlier spell files and tests are preserved at commit `62a9942fb91b6af46740a40dc085b0cbe9ad4ee0`.
 
 - [GovernanceSpell_31_03_2025](https://github.com/reserve-protocol/reserve-folio/blob/62a9942fb91b6af46740a40dc085b0cbe9ad4ee0/contracts/spells/31-03-2025/GovernanceSpell_31_03_2025.sol)
 - [UpgradeSpell_4_0_0](https://github.com/reserve-protocol/reserve-folio/blob/62a9942fb91b6af46740a40dc085b0cbe9ad4ee0/contracts/spells/upgrades/UpgradeSpell_4_0_0.sol)


### PR DESCRIPTION
## Summary

Extends the existing `docs/SPELLS.md` archive list with the exact 6.0.0 spell commit, preserving the existing document format.

Spell review: #212
Spell commit: `33c315690a71c826b5bcd01b69110f478ccd865d`
